### PR TITLE
hyperlinks fix for pypi project page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 uv add rbyte [--extra <EXTRA>]
 ```
 
-See [pyproject.toml](./pyproject.toml) for available extras.
+See [pyproject.toml](https://github.com/yaak-ai/rbyte/blob/main/pyproject.toml) for available extras.
 
-## [Examples](./examples)
+## [Examples](https://github.com/yaak-ai/rbyte/tree/main/examples)
 
 1. Install required tools:
 - [`uv`](https://github.com/astral-sh/uv)


### PR DESCRIPTION
Links relative to gh repo are not resolved by pypi

<img width="1061" alt="Screenshot 2024-10-23 at 16 32 46" src="https://github.com/user-attachments/assets/9c17d458-fb8d-458e-9bef-cb1e3020476d">
