### PR TITLE
fix: mcap decoders

### DIFF
--- a/config/_templates/dataset/nuscenes/mcap.yaml
+++ b/config/_templates/dataset/nuscenes/mcap.yaml
@@ -54,8 +54,8 @@ samples:
         func:
           _target_: rbyte.io.McapDataFrameBuilder
           decoder_factories:
-            - rbyte.utils._mcap.ProtobufDecoderFactory
-            - rbyte.utils._mcap.JsonDecoderFactory
+            - rbyte.io.ProtobufMcapDecoderFactory
+            - rbyte.io.JsonMcapDecoderFactory
           fields:
             #@ for topic in camera_topics.values():
             (@=topic@):

--- a/config/_templates/dataset/yaak.yaml
+++ b/config/_templates/dataset/yaak.yaml
@@ -104,7 +104,7 @@ samples:
         mapspec: "mcap_path[i] -> mcap[i]"
         func:
           _target_: rbyte.io.McapDataFrameBuilder
-          decoder_factories: [rbyte.utils._mcap.ProtobufDecoderFactory]
+          decoder_factories: [rbyte.io.ProtobufMcapDecoderFactory]
           fields:
             /ai/safety_score:
               clip.end_timestamp:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rbyte"
-version = "0.18.2"
+version = "0.19.0"
 description = "Multimodal PyTorch dataset library"
 authors = [{ name = "Evgenii Gorchakov", email = "evgenii@yaak.ai" }]
 maintainers = [{ name = "Evgenii Gorchakov", email = "evgenii@yaak.ai" }]

--- a/src/rbyte/io/__init__.py
+++ b/src/rbyte/io/__init__.py
@@ -38,11 +38,21 @@ else:
     __all__ += ["Hdf5DataFrameBuilder", "Hdf5TensorSource"]
 
 try:
-    from ._mcap import McapDataFrameBuilder, McapTensorSource
+    from ._mcap import (
+        JsonMcapDecoderFactory,
+        McapDataFrameBuilder,
+        McapTensorSource,
+        ProtobufMcapDecoderFactory,
+    )
 except ImportError:
     pass
 else:
-    __all__ += ["McapDataFrameBuilder", "McapTensorSource"]
+    __all__ += [
+        "JsonMcapDecoderFactory",
+        "McapDataFrameBuilder",
+        "McapTensorSource",
+        "ProtobufMcapDecoderFactory",
+    ]
 
 try:
     from .rrd import RrdDataFrameBuilder, RrdFrameSource

--- a/src/rbyte/io/_mcap/__init__.py
+++ b/src/rbyte/io/_mcap/__init__.py
@@ -1,4 +1,10 @@
 from .dataframe_builder import McapDataFrameBuilder
+from .decoders import JsonMcapDecoderFactory, ProtobufMcapDecoderFactory
 from .tensor_source import McapTensorSource
 
-__all__ = ["McapDataFrameBuilder", "McapTensorSource"]
+__all__ = [
+    "JsonMcapDecoderFactory",
+    "McapDataFrameBuilder",
+    "McapTensorSource",
+    "ProtobufMcapDecoderFactory",
+]

--- a/src/rbyte/io/_mcap/decoders/__init__.py
+++ b/src/rbyte/io/_mcap/decoders/__init__.py
@@ -1,0 +1,4 @@
+from .json_decoder_factory import JsonMcapDecoderFactory
+from .protobuf_decoder_factory import ProtobufMcapDecoderFactory
+
+__all__ = ["JsonMcapDecoderFactory", "ProtobufMcapDecoderFactory"]

--- a/src/rbyte/io/_mcap/decoders/json_decoder_factory.py
+++ b/src/rbyte/io/_mcap/decoders/json_decoder_factory.py
@@ -9,7 +9,7 @@ from structlog import get_logger
 logger = get_logger(__name__)
 
 
-class JsonDecoderFactory(McapDecoderFactory):
+class JsonMcapDecoderFactory(McapDecoderFactory):
     @override
     def decoder_for(
         self, message_encoding: str, schema: Schema | None

--- a/src/rbyte/utils/_mcap/__init__.py
+++ b/src/rbyte/utils/_mcap/__init__.py
@@ -1,3 +1,0 @@
-from .decoders import JsonDecoderFactory, ProtobufDecoderFactory
-
-__all__ = ["JsonDecoderFactory", "ProtobufDecoderFactory"]

--- a/src/rbyte/utils/_mcap/decoders/__init__.py
+++ b/src/rbyte/utils/_mcap/decoders/__init__.py
@@ -1,4 +1,0 @@
-from .json_decoder_factory import JsonDecoderFactory
-from .protobuf_decoder_factory import ProtobufDecoderFactory
-
-__all__ = ["JsonDecoderFactory", "ProtobufDecoderFactory"]


### PR DESCRIPTION
- make protobuf mcap decoder message type cache instance-bound and based on schema data
- move decoders utils -> io

fixes #54 