### PR TITLE
feat: drop `DataFrameQuery` and `DataFrameFilter`

### DIFF
--- a/config/_templates/dataset/carla.yaml
+++ b/config/_templates/dataset/carla.yaml
@@ -131,10 +131,12 @@ samples:
 
       - _target_: pipefunc.PipeFunc
         renames:
-          input: indexed
+          self: indexed
         output_name: samples
         mapspec: "indexed[i] -> samples[i]"
         func:
-          _target_: rbyte.io.DataFrameFilter
-          predicate: |
-            `control.throttle` > 0.5
+          _target_: hydra.utils.get_method
+          path: polars.DataFrame.sql
+        bound:
+          query: |
+            SELECT * FROM self WHERE `control.throttle` > 0.5

--- a/config/_templates/dataset/carla_garage.yaml
+++ b/config/_templates/dataset/carla_garage.yaml
@@ -67,11 +67,13 @@ samples:
 
       - _target_: pipefunc.PipeFunc
         renames:
-          input: records
+          self: records
         output_name: records_converted
         mapspec: "records[i] -> records_converted[i]"
         func:
-          _target_: rbyte.io.DataFrameQuery
+          _target_: hydra.utils.get_method
+          path: polars.DataFrame.sql
+        bound:
           query: |
             SELECT
               speed,
@@ -105,11 +107,13 @@ samples:
 
       - _target_: pipefunc.PipeFunc
         renames:
-          input: features
+          self: features
         output_name: features_converted
         mapspec: "features[i] -> features_converted[i]"
         func:
-          _target_: rbyte.io.DataFrameQuery
+          _target_: hydra.utils.get_method
+          path: polars.DataFrame.sql
+        bound:
           query: |
             SELECT * FROM self ORDER BY timestamp
 
@@ -182,10 +186,12 @@ samples:
 
       - _target_: pipefunc.PipeFunc
         renames:
-          input: with_waypoints_normalized
+          self: with_waypoints_normalized
         output_name: filtered
         mapspec: "with_waypoints_normalized[i] -> filtered[i]"
         func:
-          _target_: rbyte.io.DataFrameFilter
-          predicate: |
-            `meta/_idx_` between 115 and 135
+          _target_: hydra.utils.get_method
+          path: polars.DataFrame.sql
+        bound:
+          query: |
+            SELECT * FROM self WHERE `meta/_idx_` BETWEEN 115 and 135

--- a/config/_templates/dataset/nuscenes/mcap.yaml
+++ b/config/_templates/dataset/nuscenes/mcap.yaml
@@ -110,10 +110,12 @@ samples:
 
       - _target_: pipefunc.PipeFunc
         renames:
-          input: aligned
+          self: aligned
         output_name: samples
         mapspec: "aligned[i] -> samples[i]"
         func:
-          _target_: rbyte.io.DataFrameFilter
-          predicate: |
-            `/odom/vel.x` >= 8
+          _target_: hydra.utils.get_method
+          path: polars.DataFrame.sql
+        bound:
+          query: |
+            SELECT * FROM self WHERE `/odom/vel.x` >= 8

--- a/config/_templates/dataset/nuscenes/rrd.yaml
+++ b/config/_templates/dataset/nuscenes/rrd.yaml
@@ -104,10 +104,12 @@ samples:
 
       - _target_: pipefunc.PipeFunc
         renames:
-          input: aligned
+          self: aligned
         output_name: samples
         mapspec: "aligned[i] -> samples[i]"
         func:
-          _target_: rbyte.io.DataFrameFilter
-          predicate: |
-            `/world/ego_vehicle/CAM_FRONT/timestamp` between '2018-07-24 03:28:48' and '2018-07-24 03:28:50'
+          _target_: hydra.utils.get_method
+          path: polars.DataFrame.sql
+        bound:
+          query: |
+            SELECT * FROM self WHERE `/world/ego_vehicle/CAM_FRONT/timestamp` BETWEEN '2018-07-24 03:28:48' and '2018-07-24 03:28:50'

--- a/config/_templates/dataset/yaak.yaml
+++ b/config/_templates/dataset/yaak.yaml
@@ -223,13 +223,15 @@ samples:
 
       - _target_: pipefunc.PipeFunc
         renames:
-          input: aligned
+          self: aligned
         output_name: filtered
         mapspec: "aligned[i] -> filtered[i]"
         func:
-          _target_: rbyte.io.DataFrameFilter
-          predicate: |
-            `meta/VehicleMotion/speed` > 44
+          _target_: hydra.utils.get_method
+          path: polars.DataFrame.sql
+        bound:
+          query: |
+            SELECT * FROM self WHERE `meta/VehicleMotion/speed` > 44
 
       #@ for i, camera in enumerate(cameras):
       - _target_: pipefunc.PipeFunc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rbyte"
-version = "0.19.0"
+version = "0.20.0"
 description = "Multimodal PyTorch dataset library"
 authors = [{ name = "Evgenii Gorchakov", email = "evgenii@yaak.ai" }]
 maintainers = [{ name = "Evgenii Gorchakov", email = "evgenii@yaak.ai" }]

--- a/src/rbyte/io/__init__.py
+++ b/src/rbyte/io/__init__.py
@@ -3,11 +3,9 @@ from ._numpy import NumpyTensorSource
 from .dataframe import (
     DataFrameAligner,
     DataFrameConcater,
-    DataFrameFilter,
     DataFrameFpsResampler,
     DataFrameIndexer,
     DataFrameJoiner,
-    DataFrameQuery,
     DataFrameWithColumns,
     FixedWindowSampleBuilder,
 )
@@ -16,11 +14,9 @@ from .path import PathDataFrameBuilder, PathTensorSource
 __all__: list[str] = [
     "DataFrameAligner",
     "DataFrameConcater",
-    "DataFrameFilter",
     "DataFrameFpsResampler",
     "DataFrameIndexer",
     "DataFrameJoiner",
-    "DataFrameQuery",
     "DataFrameWithColumns",
     "FixedWindowSampleBuilder",
     "JsonDataFrameBuilder",

--- a/src/rbyte/io/dataframe/__init__.py
+++ b/src/rbyte/io/dataframe/__init__.py
@@ -4,16 +4,14 @@ from .fps_resampler import DataFrameFpsResampler
 from .indexer import DataFrameIndexer
 from .joiner import DataFrameJoiner
 from .sample_builder import FixedWindowSampleBuilder
-from .sql import DataFrameFilter, DataFrameQuery, DataFrameWithColumns
+from .sql import DataFrameWithColumns
 
 __all__ = [
     "DataFrameAligner",
     "DataFrameConcater",
-    "DataFrameFilter",
     "DataFrameFpsResampler",
     "DataFrameIndexer",
     "DataFrameJoiner",
-    "DataFrameQuery",
     "DataFrameWithColumns",
     "FixedWindowSampleBuilder",
 ]

--- a/src/rbyte/io/dataframe/sql.py
+++ b/src/rbyte/io/dataframe/sql.py
@@ -1,36 +1,7 @@
-from functools import partial
-from typing import TYPE_CHECKING, final
+from typing import final
 
 import polars as pl
 from pydantic import validate_call
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
-
-class DataFrameQuery:
-    __name__: str = __qualname__
-
-    @validate_call
-    def __init__(self, *, query: str, table_name: str = "self") -> None:
-        self._fn: Callable[[pl.DataFrame], pl.DataFrame] = partial(
-            pl.DataFrame.sql, query=query, table_name=table_name
-        )
-
-    def __call__(self, input: pl.DataFrame) -> pl.DataFrame:
-        return self._fn(input)
-
-
-@final
-class DataFrameFilter(DataFrameQuery):
-    __name__ = __qualname__
-
-    @validate_call
-    def __init__(self, predicate: str) -> None:
-        super().__init__(
-            query=f"select * from {(table_name := 'self')} where {predicate}",  # noqa: S608
-            table_name=table_name,
-        )
 
 
 @final


### PR DESCRIPTION
... in favour of direct `polars.DataFrame.sql` usage

fixes #52 (`query` can be a regular or a bound argument)