### PR TITLE
feat: columnwise `gather_every` in `DataFrameGroupByDynamic`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: pyupgrade
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.11.7
     hooks:
       - id: ruff
         args: [--fix]

--- a/config/_templates/dataset/yaak.yaml
+++ b/config/_templates/dataset/yaak.yaml
@@ -265,24 +265,25 @@ samples:
 
       - _target_: pipefunc.PipeFunc
         renames:
-          self: with_waypoints_normalized
-        output_name: cleaned
-        mapspec: "with_waypoints_normalized[i] -> cleaned[i]"
+          input: with_waypoints_normalized
+        output_name: samples
+        mapspec: "with_waypoints_normalized[i] -> samples[i]"
+        func:
+          _target_: rbyte.io.DataFrameGroupByDynamic
+          index_column: meta/ImageMetadata.(@=cameras[0]@)/frame_idx
+          every: 6i
+          period: 6i
+
+      - _target_: pipefunc.PipeFunc
+        renames:
+          self: samples
+        output_name: samples_cleaned
+        mapspec: "samples[i] -> samples_cleaned[i]"
         func:
           _target_: hydra.utils.get_method
           path: polars.DataFrame.sql
         bound:
           query: |
-            SELECT * EXCLUDE `meta/Gnss/longitude_latitude` FROM self
-
-      - _target_: pipefunc.PipeFunc
-        renames:
-          input: cleaned
-        output_name: samples
-        mapspec: "cleaned[i] -> samples[i]"
-        func:
-          _target_: rbyte.io.FixedWindowSampleBuilder
-          index_column: meta/ImageMetadata.(@=cameras[0]@)/frame_idx
-          every: 6i
-          period: 6i
-          length: 6
+            SELECT * EXCLUDE `meta/Gnss/longitude_latitude`
+            FROM self
+            WHERE ARRAY_LENGTH(`meta/ImageMetadata.(@=cameras[0]@)/frame_idx`) == 6

--- a/config/_templates/dataset/zod.yaml
+++ b/config/_templates/dataset/zod.yaml
@@ -158,6 +158,6 @@ samples:
         output_name: samples
         mapspec: "filtered[i] -> samples[i]"
         func:
-          _target_: rbyte.io.FixedWindowSampleBuilder
+          _target_: rbyte.io.DataFrameGroupByDynamic
           index_column: camera_front_blur_meta/timestamp
           every: 300ms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rbyte"
-version = "0.23.1"
+version = "0.24.0"
 description = "Multimodal PyTorch dataset library"
 authors = [{ name = "Evgenii Gorchakov", email = "evgenii@yaak.ai" }]
 maintainers = [{ name = "Evgenii Gorchakov", email = "evgenii@yaak.ai" }]
@@ -8,7 +8,7 @@ dependencies = [
   "tensordict>=0.7.2",
   "torch",
   "numpy",
-  "polars[pyarrow]>=1.27.1",
+  "polars[pyarrow]>=1.28.1",
   "duckdb>=1.2.2",
   "pydantic>=2.11.3",
   "more-itertools>=10.6.0",

--- a/src/rbyte/io/__init__.py
+++ b/src/rbyte/io/__init__.py
@@ -4,8 +4,8 @@ from .dataframe import (
     DataFrameAligner,
     DataFrameConcater,
     DataFrameDuckDbQuery,
+    DataFrameGroupByDynamic,
     DataFrameIndexer,
-    FixedWindowSampleBuilder,
 )
 from .path import PathDataFrameBuilder, PathTensorSource
 
@@ -13,9 +13,9 @@ __all__: list[str] = [
     "DataFrameAligner",
     "DataFrameConcater",
     "DataFrameDuckDbQuery",
+    "DataFrameGroupByDynamic",
     "DataFrameIndexer",
     "DuckDbDataFrameBuilder",
-    "FixedWindowSampleBuilder",
     "NumpyTensorSource",
     "PathDataFrameBuilder",
     "PathTensorSource",

--- a/src/rbyte/io/dataframe/__init__.py
+++ b/src/rbyte/io/dataframe/__init__.py
@@ -1,13 +1,13 @@
 from .aligner import DataFrameAligner
 from .concater import DataFrameConcater
+from .groupby import DataFrameGroupByDynamic
 from .indexer import DataFrameIndexer
-from .sample_builder import FixedWindowSampleBuilder
 from .sql import DataFrameDuckDbQuery
 
 __all__ = [
     "DataFrameAligner",
     "DataFrameConcater",
     "DataFrameDuckDbQuery",
+    "DataFrameGroupByDynamic",
     "DataFrameIndexer",
-    "FixedWindowSampleBuilder",
 ]


### PR DESCRIPTION
this would allow for per-column (= per output key) intra-window "sampling rates", e.g. scenarios like "given 100 frame indices take all corresponding speed values but only every 10th frame" 