### PR TITLE
feat: "native" pydantic config support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
 
-      - run: just sync
+      - run: uv sync --all-extras --group test
       - run: just build
       - run: just format --check
       - run: just lint

--- a/config/_templates/dataset/yaak.yaml
+++ b/config/_templates/dataset/yaak.yaml
@@ -207,6 +207,7 @@ samples:
                     tolerance: 500ms
                     strategy: nearest
                   score:
+                    method: asof
                     tolerance: 500ms
                     strategy: nearest
 
@@ -237,6 +238,7 @@ samples:
           _target_: rbyte.io.DataFrameDuckDbQuery
         bound:
           query: |
+            LOAD spatial;
             SELECT
               *,
               ST_AsWKB(ST_Transform(ST_Point("meta/Gnss/longitude", "meta/Gnss/latitude"), 'EPSG:4326', 'EPSG:3857')) as "meta/Gnss/longitude_latitude"

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ _default:
     @just --list --unsorted
 
 sync:
-    uv sync --all-extras --dev
+    uv sync --all-extras --all-groups
 
 install-tools:
     uv tool install --force --upgrade ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rbyte"
-version = "0.26.1"
+version = "0.27.0"
 description = "Multimodal PyTorch dataset library"
 authors = [{ name = "Evgenii Gorchakov", email = "evgenii@yaak.ai" }]
 maintainers = [{ name = "Evgenii Gorchakov", email = "evgenii@yaak.ai" }]
@@ -10,14 +10,14 @@ dependencies = [
   "numpy",
   "polars[pyarrow]>=1.29.0",
   "duckdb>=1.2.2",
-  "pydantic>=2.11.3",
+  "pydantic>=2.11.4",
   "more-itertools>=10.6.0",
   "hydra-core>=1.3.2",
   "optree>=0.15.0",
   "cachetools>=5.5.2",
   "structlog>=25.2.0",
   "tqdm>=4.67.1",
-  "pipefunc[autodoc]>=0.68.0",
+  "pipefunc[autodoc]>=0.76.0",
   "xxhash>=3.5.0",
 ]
 readme = "README.md"
@@ -81,10 +81,13 @@ dev = [
   "pudb>=2024.1.2",
   "ipython>=8.32.0",
   "ipython-autoimport>=0.5",
-  "pytest>=8.3.5",
-  "testbook>=0.4.2",
   "ipykernel>=6.29.5",
   "pipefunc[plotting]",
+]
+test = [
+  "pytest>=8.3.5",
+  "pytest-lazy-fixtures>=1.1.2",
+  "testbook>=0.4.2",
 ]
 
 [tool.hatch.metadata]

--- a/src/rbyte/config/base.py
+++ b/src/rbyte/config/base.py
@@ -17,9 +17,13 @@ class BaseModel(_BaseModel):
 
 
 class HydraConfig[T](BaseModel):
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        extra="allow", populate_by_name=True
+    )
 
-    target: ImportString[type[T]] = Field(alias="_target_")
+    target: ImportString[type[T]] = Field(
+        serialization_alias="_target_", validation_alias="_target_"
+    )
     recursive: bool = Field(alias="_recursive_", default=True)
     convert: Literal["none", "partial", "object", "all"] = Field(
         alias="_convert_", default="all"

--- a/src/rbyte/io/dataframe/aligner.py
+++ b/src/rbyte/io/dataframe/aligner.py
@@ -40,7 +40,7 @@ class AlignConfig(BaseModel):
     columns: OrderedDict[str, ColumnAlignConfig] = Field(default_factory=OrderedDict)
 
 
-type Fields = AlignConfig | OrderedDict[str, Fields]
+type Fields = OrderedDict[str, AlignConfig | Fields]
 
 
 @final

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,10 +1,38 @@
+from collections import OrderedDict
 from pathlib import Path
 from types import SimpleNamespace
 
+import polars as pl
+import pytest
 from hydra import compose, initialize
 from hydra.utils import instantiate
+from pipefunc import PipeFunc, Pipeline
+from pipefunc.helpers import collect_kwargs
+from pytest_lazy_fixtures import lf
 from structlog import get_logger
 from torch import Tensor
+
+from rbyte import Dataset
+from rbyte.config.base import HydraConfig
+from rbyte.dataset import PipelineInstanceConfig, SourceConfig, SourcesConfig
+from rbyte.io import (
+    DataFrameAligner,
+    DataFrameDuckDbQuery,
+    DataFrameGroupByDynamic,
+    DuckDbDataFrameBuilder,
+    McapDataFrameBuilder,
+    ProtobufMcapDecoderFactory,
+    TorchCodecFrameSource,
+    VideoDataFrameBuilder,
+    WaypointBuilder,
+    WaypointNormalizer,
+    YaakMetadataDataFrameBuilder,
+)
+from rbyte.io.dataframe.aligner import (
+    AlignConfig,
+    AsofColumnAlignConfig,
+    InterpColumnAlignConfig,
+)
 
 logger = get_logger(__name__)
 
@@ -12,13 +40,316 @@ CONFIG_PATH = "../config"
 DATA_DIR = Path(__file__).resolve().parent / "data"
 
 
-def test_yaak() -> None:
+@pytest.fixture
+def yaak_pydantic() -> Dataset:
+    data_dir = DATA_DIR / "yaak"
+    drive_ids = ["Niro098-HQ/2024-06-18--13-39-54"]
+    cameras = ["cam_front_left", "cam_left_backward", "cam_right_backward"]
+
+    samples = PipelineInstanceConfig(
+        inputs={
+            input_id: {
+                "meta_path": data_dir / input_id / "metadata.log",
+                "mcap_path": data_dir / input_id / "ai.mcap",
+                "waypoints_path": data_dir / input_id / "waypoints.json",
+            }
+            | {
+                f"{camera}_path": data_dir / input_id / f"{camera}.pii.mp4"
+                for camera in cameras
+            }
+            for input_id in drive_ids
+        },
+        parallel=False,  # pyright: ignore[reportCallIssue]
+        storage="dict",  # pyright: ignore[reportCallIssue]
+        pipeline=Pipeline(
+            validate_type_annotations=False,
+            functions=[
+                PipeFunc(
+                    renames={"path": "meta_path"},
+                    output_name="meta",
+                    mapspec="meta_path[i] -> meta[i]",
+                    func=YaakMetadataDataFrameBuilder(
+                        fields={
+                            "rbyte.io.yaak.proto.sensor_pb2.ImageMetadata": {  # pyright: ignore[reportArgumentType]
+                                "time_stamp": pl.Datetime(),
+                                "frame_idx": pl.Int32(),
+                                "camera_name": pl.Enum((
+                                    "cam_front_center",
+                                    "cam_front_left",
+                                    "cam_front_right",
+                                    "cam_left_forward",
+                                    "cam_right_forward",
+                                    "cam_left_backward",
+                                    "cam_right_backward",
+                                    "cam_rear",
+                                )),
+                            },
+                            "rbyte.io.yaak.proto.can_pb2.VehicleMotion": {
+                                "time_stamp": pl.Datetime(),
+                                "speed": pl.Float32(),
+                            },
+                            "rbyte.io.yaak.proto.sensor_pb2.Gnss": {
+                                "time_stamp": pl.Datetime(),
+                                "latitude": pl.Float32(),
+                                "longitude": pl.Float32(),
+                            },
+                        }
+                    ),
+                ),
+                *(
+                    PipeFunc(
+                        renames={"path": f"{camera}_path"},
+                        output_name=f"{camera}_meta",
+                        mapspec=f"{camera}_path[i] -> {camera}_meta[i]",
+                        func=VideoDataFrameBuilder(fields={"frame_idx": pl.Int32()}),
+                    )
+                    for camera in cameras
+                ),
+                PipeFunc(
+                    renames={"path": "mcap_path"},
+                    output_name="mcap",
+                    mapspec="mcap_path[i] -> mcap[i]",
+                    func=McapDataFrameBuilder(
+                        decoder_factories=[ProtobufMcapDecoderFactory],
+                        fields={
+                            "/ai/safety_score": {
+                                "clip.end_timestamp": pl.Datetime(),
+                                "score": pl.Float32(),
+                            }
+                        },
+                    ),
+                ),
+                PipeFunc(
+                    renames={"path": "waypoints_path"},
+                    output_name="waypoints_raw",
+                    mapspec="waypoints_path[i] -> waypoints_raw[i]",
+                    func=DuckDbDataFrameBuilder(),
+                    bound={
+                        "query": """
+LOAD spatial;
+SELECT TO_TIMESTAMP(timestamp)::TIMESTAMP as timestamp,
+   heading,
+   ST_AsWKB(ST_Transform(geom, 'EPSG:4326', 'EPSG:3857')) AS geometry
+FROM ST_Read('{path}')
+"""
+                    },
+                ),
+                PipeFunc(
+                    renames={"input": "waypoints_raw"},
+                    output_name="waypoints",
+                    mapspec="waypoints_raw[i] -> waypoints[i]",
+                    func=WaypointBuilder(
+                        length=10,
+                        columns=WaypointBuilder.Columns(
+                            points="geometry", output="waypoints"
+                        ),
+                    ),
+                ),
+                PipeFunc(
+                    output_name="data",
+                    mapspec="meta[i], mcap[i], waypoints[i] -> data[i]",
+                    func=collect_kwargs(parameters=("meta", "mcap", "waypoints")),
+                ),
+                PipeFunc(
+                    renames={"input": "data"},
+                    output_name="aligned",
+                    mapspec="data[i] -> aligned[i]",
+                    func=DataFrameAligner(
+                        separator="/",
+                        fields=OrderedDict({
+                            "meta": OrderedDict({
+                                **{
+                                    f"ImageMetadata.{camera}": AlignConfig(
+                                        key="time_stamp",
+                                        columns=OrderedDict(
+                                            {}
+                                            if i == 0
+                                            else {
+                                                "frame_idx": AsofColumnAlignConfig(
+                                                    strategy="nearest", tolerance="20ms"
+                                                )
+                                            }
+                                        ),
+                                    )
+                                    for i, camera in enumerate(cameras)
+                                },
+                                "VehicleMotion": AlignConfig(
+                                    key="time_stamp",
+                                    columns=OrderedDict(
+                                        speed=InterpColumnAlignConfig()
+                                    ),
+                                ),
+                                "Gnss": AlignConfig(
+                                    key="time_stamp",
+                                    columns=OrderedDict(
+                                        latitude=AsofColumnAlignConfig(
+                                            strategy="nearest", tolerance="500ms"
+                                        ),
+                                        longitude=AsofColumnAlignConfig(
+                                            strategy="nearest", tolerance="500ms"
+                                        ),
+                                    ),
+                                ),
+                            }),
+                            "mcap": OrderedDict({
+                                "/ai/safety_score": AlignConfig(
+                                    key="clip.end_timestamp",
+                                    columns=OrderedDict({
+                                        "clip.end_timestamp": AsofColumnAlignConfig(
+                                            strategy="nearest", tolerance="500ms"
+                                        ),
+                                        "score": AsofColumnAlignConfig(
+                                            strategy="nearest", tolerance="500ms"
+                                        ),
+                                    }),
+                                )
+                            }),
+                            "waypoints": AlignConfig(
+                                key="timestamp",
+                                columns=OrderedDict({
+                                    "heading": AsofColumnAlignConfig(
+                                        strategy="nearest"
+                                    ),
+                                    "waypoints": AsofColumnAlignConfig(
+                                        strategy="nearest"
+                                    ),
+                                }),
+                            ),
+                        }),
+                    ),
+                ),
+                PipeFunc(
+                    output_name="query_context",
+                    mapspec=(
+                        ", ".join(["aligned[i]", *map("{}_meta[i]".format, cameras)])
+                        + " -> query_context[i]"
+                    ),
+                    func=collect_kwargs(
+                        parameters=("aligned", *map("{}_meta".format, cameras))
+                    ),
+                ),
+                PipeFunc(
+                    renames={"context": "query_context"},
+                    output_name="filtered",
+                    mapspec="query_context[i] -> filtered[i]",
+                    func=DataFrameDuckDbQuery(),
+                    bound={
+                        "query": """
+LOAD spatial;
+SELECT
+    *,
+    ST_ASWKB(
+        ST_TRANSFORM(
+            ST_POINT("meta/Gnss/longitude", "meta/Gnss/latitude"),
+            'EPSG:4326',
+            'EPSG:3857'
+        )
+    ) AS "meta/Gnss/longitude_latitude"
+FROM aligned
+
+SEMI JOIN cam_front_left_meta
+ON aligned."meta/ImageMetadata.cam_front_left/frame_idx" =
+    cam_front_left_meta.frame_idx
+
+SEMI JOIN cam_left_backward_meta
+ON aligned."meta/ImageMetadata.cam_left_backward/frame_idx" =
+    cam_left_backward_meta.frame_idx
+
+SEMI JOIN cam_right_backward_meta
+ON aligned."meta/ImageMetadata.cam_right_backward/frame_idx" =
+    cam_right_backward_meta.frame_idx
+
+WHERE COLUMNS (*) IS NOT NULL AND "meta/VehicleMotion/speed" > 44
+"""
+                    },
+                ),
+                PipeFunc(
+                    renames={"input": "filtered"},
+                    output_name="with_waypoints_normalized",
+                    mapspec="filtered[i] -> with_waypoints_normalized[i]",
+                    func=WaypointNormalizer(
+                        columns=WaypointNormalizer.Columns(
+                            ego="meta/Gnss/longitude_latitude",
+                            waypoints="waypoints/waypoints",
+                            heading="waypoints/heading",
+                            output="waypoints/waypoints_normalized",
+                        )
+                    ),
+                ),
+                PipeFunc(
+                    renames={"input": "with_waypoints_normalized"},
+                    output_name="samples",
+                    mapspec="with_waypoints_normalized[i] -> samples[i]",
+                    func=DataFrameGroupByDynamic(
+                        index_column=f"meta/ImageMetadata.{cameras[0]}/frame_idx",
+                        every="6i",
+                        period="6i",
+                    ),
+                ),
+                PipeFunc(
+                    renames={"df": "samples"},
+                    output_name="samples_cast",
+                    mapspec="samples[i] -> samples_cast[i]",
+                    func=DataFrameDuckDbQuery(),
+                    bound={
+                        "query": """
+SELECT
+   "meta/ImageMetadata.cam_front_left/time_stamp"::TIMESTAMP[6]
+        AS "meta/ImageMetadata.cam_front_left/time_stamp",
+   "meta/ImageMetadata.cam_front_left/frame_idx"::INT32[6]
+        AS "meta/ImageMetadata.cam_front_left/frame_idx",
+   "meta/ImageMetadata.cam_left_backward/frame_idx"::INT32[6]
+        AS "meta/ImageMetadata.cam_left_backward/frame_idx",
+   "meta/ImageMetadata.cam_right_backward/frame_idx"::INT32[6]
+        AS "meta/ImageMetadata.cam_right_backward/frame_idx",
+   "meta/VehicleMotion/speed"::FLOAT[6]
+        AS "meta/VehicleMotion/speed",
+   "mcap//ai/safety_score/clip.end_timestamp"::TIMESTAMP[6]
+        AS "mcap//ai/safety_score/clip.end_timestamp",
+   "mcap//ai/safety_score/score"::FLOAT[6]
+        AS "mcap//ai/safety_score/score",
+   "waypoints/heading"::FLOAT[6]
+        AS "waypoints/heading",
+   "waypoints/waypoints_normalized"::FLOAT[2][10][6]
+        AS "waypoints/waypoints_normalized"
+FROM df
+WHERE len("meta/ImageMetadata.cam_front_left/frame_idx") == 6
+"""
+                    },
+                ),
+            ],
+        ),
+    )
+
+    sources = SourcesConfig({
+        drive_id: {
+            camera: SourceConfig(
+                index_column=f"meta/ImageMetadata.{camera}/frame_idx",
+                source=HydraConfig(
+                    target=TorchCodecFrameSource,
+                    source=data_dir / drive_id / f"{camera}.pii.mp4",  # pyright: ignore[reportCallIssue]
+                ),
+            )
+            for camera in cameras
+        }
+        for drive_id in drive_ids
+    })
+
+    return Dataset(samples=samples, sources=sources)
+
+
+@pytest.fixture
+def yaak_hydra() -> Dataset:
     with initialize(version_base=None, config_path=CONFIG_PATH):
         cfg = compose(
             "visualize", overrides=["dataset=yaak", f"+data_dir={DATA_DIR}/yaak"]
         )
 
-    dataset = instantiate(cfg.dataset)
+    return instantiate(cfg.dataset)
+
+
+@pytest.mark.parametrize("dataset", [lf("yaak_hydra"), lf("yaak_pydantic")])
+def test_yaak(dataset: Dataset) -> None:
     index = [0, 2]
     c = SimpleNamespace(B=len(index))
 
@@ -55,7 +386,8 @@ def test_yaak() -> None:
 
     match (
         batch := dataset.get_batch(
-            index, keys={"data", ("data", "meta/VehicleMotion/speed"), "meta"}
+            index,
+            keys={"data", ("data", "meta/VehicleMotion/speed"), "meta"},  # pyright: ignore[reportArgumentType]
         )
     ).to_dict():
         case {
@@ -71,7 +403,7 @@ def test_yaak() -> None:
             raise AssertionError(msg)
 
     match (
-        batch := dataset.get_batch(index, keys={("data", "meta/VehicleMotion/speed")})
+        batch := dataset.get_batch(index, keys={("data", "meta/VehicleMotion/speed")})  # pyright: ignore[reportArgumentType]
     ).to_dict():
         case {
             "data": {"meta/VehicleMotion/speed": Tensor(shape=[c.B, *_]), **data_rest},
@@ -85,7 +417,7 @@ def test_yaak() -> None:
 
             raise AssertionError(msg)
 
-    match (batch := dataset.get_batch(index, keys={("meta", "input_id")})).to_dict():
+    match (batch := dataset.get_batch(index, keys={("meta", "input_id")})).to_dict():  # pyright: ignore[reportArgumentType]
         case {"data": None, "meta": {"input_id": [*_]}, **batch_rest} if not batch_rest:
             pass
 


### PR DESCRIPTION
see the `yaak_pydantic` and `yaak_hydra` fixtures in `./tests/test_dataset.py` that produce equivalent datasets from a Pydantic model and a yaml file respectively