### PR TITLE
bugfix: pin duckdb timezone

### DIFF
--- a/config/_templates/dataset/yaak.yaml
+++ b/config/_templates/dataset/yaak.yaml
@@ -133,6 +133,7 @@ samples:
         bound:
           query: |
             LOAD spatial;
+            SET TimeZone = 'UTC';
             SELECT TO_TIMESTAMP(timestamp)::TIMESTAMP as timestamp,
                    heading,
                    ST_AsWKB(ST_Transform(geom, 'EPSG:4326', 'EPSG:3857')) AS geometry


### PR DESCRIPTION
`polars` loads timestamps in UTC, while `duckdb` uses local timezone. As a result in `yaak` dataset final metadata and waypoints timestamps are 1-2 hours different and waypoints are not properly aligned. 