### PR TITLE
feat: rerun waypoints logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,25 +16,25 @@ repos:
       - id: pyupgrade
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.0
+    rev: v0.15.12
     hooks:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/tombi-toml/tombi-pre-commit
-    rev: v0.7.27
+    rev: v0.10.2
     hooks:
       - id: tombi-format
       - id: tombi-lint
 
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.9.0
+    rev: 0.9.1
     hooks:
       - id: nbstripout
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770169770,
-        "narHash": "sha256-awR8qIwJxJJiOmcEGgP2KUqYmHG4v/z8XpL9z8FnT1A=",
+        "lastModified": 1777826146,
+        "narHash": "sha256-wQ/iN5Zp5VIa3ebBibijPnLyKhor+xEbDy4d0goa9Zs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "aa290c9891fa4ebe88f8889e59633d20cc06a5f2",
+        "rev": "73c703c22422b8951895a960959dbbaca7296492",
         "type": "github"
       },
       "original": {

--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ sync:
 setup: sync
     git submodule update --init --recursive --force --remote
     git lfs pull
-    uvx prek@latest install
+    uvx prek@latest install --overwrite
 
 build:
     uv build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rbyte"
-version = "0.34.6"
+version = "0.35.0"
 description = "Multimodal PyTorch dataset library"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -19,15 +19,15 @@ classifiers = [
 dependencies = [
   "cachetools>=7.0.0",
   "checkedframe>=0.1.0",
-  "duckdb>=1.4.4",
+  "duckdb>=1.5.2",
   "hydra-core>=1.3.2",
   "makefun>=1.16.0",
   "more-itertools>=10.8.0",
   "numpy",
   "optree>=0.18.0",
   "pipefunc[autodoc]>=0.90.2",
-  "polars>=1.38.0",
-  "pydantic>=2.12.5",
+  "polars>=1.40.1",
+  "pydantic>=2.13.3",
   "structlog>=25.5.0",
   "tensordict>=0.11.0",  # https://github.com/pytorch/tensordict/issues/1440
   "torch",
@@ -53,7 +53,7 @@ protos = ["grpcio-tools==1.71.0", "protoletariat>=3.3.10"]
 video = ["torchcodec>=0.10.0"]
 visualize = [
   "einops>=0.8.2",
-  "rerun-sdk[notebook]>=0.29.0",
+  "rerun-sdk[notebook]>=0.31.4",
 ]
 yaak = ["ptars==0.0.5", "protobuf"]
 
@@ -71,8 +71,8 @@ dev = [
   "wat-inspector>=0.4.3",
 ]
 check = [
-  "ruff>=0.15.0",
-  "ty>=0.0.15",
+  "ruff>=0.15.12",
+  "ty>=0.0.34",
 ]
 test = [
   "dill>=0.4.1",

--- a/src/rbyte/dataloader.py
+++ b/src/rbyte/dataloader.py
@@ -26,9 +26,7 @@ class BatchIndexableDataset(Protocol):
 class MapAndCollate[T]:
     @validate_call
     def __init__(
-        self,
-        dataset: InstanceOf[BatchIndexableDataset],
-        collate_fn: Callable[[...], Any],
+        self, dataset: InstanceOf[BatchIndexableDataset], collate_fn: Callable[..., Any]
     ) -> None:
         self._dataset = dataset
         self._collate_fn = collate_fn
@@ -49,7 +47,7 @@ class TorchDataNodeDataLoader[T](Iterable[T], Sized):
         batch_size: int = 1,
         shuffle: bool | None = None,
         num_workers: PositiveInt = 1,
-        collate_fn: Callable[[...], Any] | None = None,
+        collate_fn: Callable[..., Any] | None = None,
         pin_memory: bool = False,
         pin_memory_device: str = "",
         drop_last: bool = False,

--- a/src/rbyte/dataset.py
+++ b/src/rbyte/dataset.py
@@ -142,17 +142,17 @@ class Dataset(TorchDataset[Batch]):  # noqa: PLW1641
                 stream_data = {stream_id: [] for stream_id in self.streams}  # ty: ignore[not-iterable]
 
                 for sample, input_id in zip(data, meta["input_id"], strict=True):
-                    for stream_id, stream_config in self.streams.items():  # ty: ignore[possibly-missing-attribute]
+                    for stream_id, stream_config in self.streams.items():  # ty:ignore[unresolved-attribute]
                         stream_index = sample[stream_config.index].tolist()
                         source = self._get_source(stream_id, input_id)
                         stream_data[stream_id].append(source[stream_index])
 
                 stream_data = {k: torch.stack(v) for k, v in stream_data.items()}
 
-                if data.is_locked:  # ty: ignore[possibly-missing-attribute]
+                if data.is_locked:  # ty:ignore[unresolved-attribute]
                     data = data.clone(recurse=True)  # ty: ignore[unknown-argument]
 
-                data = data.update(stream_data, inplace=False)  # ty: ignore[possibly-missing-attribute]
+                data = data.update(stream_data, inplace=False)  # ty:ignore[unresolved-attribute]
 
             case True, None:
                 msg = "`include_streams` is True but no streams specified"

--- a/src/rbyte/io/_duckdb/dataframe_query.py
+++ b/src/rbyte/io/_duckdb/dataframe_query.py
@@ -17,7 +17,7 @@ logger = get_logger(__name__)
 
 def _validate_query(query: str) -> str:
     match duckdb.extract_statements(query):
-        case [Statement(type=StatementType.SELECT)]:  # ty: ignore[unresolved-attribute]
+        case [Statement(type=StatementType.SELECT)]:
             pass
 
         case _:

--- a/src/rbyte/io/_mcap/dataframe_builder.py
+++ b/src/rbyte/io/_mcap/dataframe_builder.py
@@ -108,13 +108,14 @@ class McapDataFrameBuilder:
                 )
 
                 row_df = pl.DataFrame(
-                    [getattr(dmt.message, field) for field in special_fields],
-                    schema=special_fields,
+                    [getattr(dmt.message, field) for field in special_fields],  # ty:ignore[not-iterable]
+                    schema=special_fields,  # ty:ignore[invalid-argument-type]
                 )
 
                 if (
                     message_df := self._build_message_df(
-                        dmt.decoded_message, message_fields
+                        dmt.decoded_message,
+                        message_fields,  # ty:ignore[invalid-argument-type]
                     )
                 ) is not None:
                     row_df = message_df.hstack(row_df)
@@ -142,13 +143,13 @@ class McapDataFrameBuilder:
                     .lazy()
                     .unnest(cs.struct(), separator=".")
                     .select(fields.keys())
-                    .cast(df_schema)
+                    .cast(df_schema)  # ty:ignore[invalid-argument-type]
                 ).collect()  # ty:ignore[invalid-return-type]
 
             case _:
                 return pl.from_dict({
                     field: attrgetter(field)(message) for field in fields
-                }).cast(df_schema)
+                }).cast(df_schema)  # ty:ignore[invalid-argument-type]
 
     @cached_property
     def _decoder_factories_instantiated(self) -> tuple[DecoderFactory, ...]:

--- a/src/rbyte/io/_mcap/decoders/protobuf_decoder_factory.py
+++ b/src/rbyte/io/_mcap/decoders/protobuf_decoder_factory.py
@@ -37,7 +37,7 @@ class ProtobufMcapDecoderFactory(McapDecoderFactory):
             and schema.encoding == SchemaEncoding.Protobuf
         ):
             message_type = self._get_message_type(schema)
-            handler = self._handler_pool.get_for_message(message_type.DESCRIPTOR)
+            handler = self._handler_pool.get_for_message(message_type.DESCRIPTOR)  # ty:ignore[invalid-argument-type]
 
             def decoder(data: bytes) -> pl.DataFrame:
                 record_batch = handler.list_to_record_batch([data])

--- a/src/rbyte/io/_mcap/tensor_source.py
+++ b/src/rbyte/io/_mcap/tensor_source.py
@@ -123,7 +123,7 @@ class McapTensorSource(TensorSource[int]):
                         stream.read(message_index.message_start_offset - stream.count)
                         message = Message.read(stream, message_index.message_length)
                         decoded_message = self._message_decoder(message.data)
-                        arrays[index] = self._decoder(decoded_message.data)
+                        arrays[index] = self._decoder(decoded_message.data)  # ty:ignore[invalid-assignment]
 
                 tensors = [torch.from_numpy(arrays[idx]) for idx in indexes]  # ty: ignore[invalid-argument-type]
 
@@ -140,9 +140,6 @@ class McapTensorSource(TensorSource[int]):
                 array = self._decoder(decoded_message.data)
 
                 return torch.from_numpy(array)
-
-            case _:
-                raise ValueError
 
     @override
     def __len__(self) -> int:

--- a/src/rbyte/io/dataframe/concater.py
+++ b/src/rbyte/io/dataframe/concater.py
@@ -39,7 +39,7 @@ class DataFrameConcater:
 
                 return self._fn([
                     v.lazy().with_columns(
-                        pl.lit(k).cast(key_enum).alias(self._key_column)
+                        pl.lit(k).cast(key_enum).alias(self._key_column)  # ty:ignore[invalid-argument-type]
                     )
-                    for k, v in zip(keys, values, strict=True)  # ty: ignore[invalid-argument-type]
+                    for k, v in zip(keys, values, strict=True)  # ty: ignore[invalid-argument-type, not-iterable]
                 ]).collect()

--- a/src/rbyte/io/geo/waypoints.py
+++ b/src/rbyte/io/geo/waypoints.py
@@ -50,5 +50,5 @@ class WaypointBuilder:
             .join(lf, on=self._index_column, how="left")
             .drop(self._index_column)
             .collect()
-            .head(-(self._length - 1))
+            .head(-(self._length - 1))  # ty:ignore[unresolved-attribute]
         )

--- a/src/rbyte/io/video/torchcodec_source.py
+++ b/src/rbyte/io/video/torchcodec_source.py
@@ -83,13 +83,10 @@ class TorchCodecFrameSource(TensorSource[int]):
     def __getitem__(self, indexes: int | Sequence[int]) -> Tensor:
         match indexes:
             case Sequence():
-                return self._decoder.get_frames_at(indices=list(indexes)).data
+                return self._decoder.get_frames_at(indices=list(indexes)).data  # ty:ignore[invalid-argument-type]
 
             case int():
                 return self._decoder.get_frame_at(index=indexes).data
-
-            case _:
-                raise ValueError
 
     @override
     def __len__(self) -> int:

--- a/src/rbyte/io/yaak/metadata/dataframe_builder.py
+++ b/src/rbyte/io/yaak/metadata/dataframe_builder.py
@@ -16,7 +16,7 @@ from tqdm import tqdm
 from xxhash import xxh3_64_hexdigest as digest
 
 from rbyte.config import PickleableImportString
-from rbyte.io.yaak.proto import sensor_pb2
+from rbyte.io.yaak.proto.sensor_pb2 import ImageMetadata
 
 from .message_iterator import YaakMetadataMessageIterator
 
@@ -81,7 +81,7 @@ class YaakMetadataDataFrameBuilder:
                 for msg, schema in self._fields.items()
             }
 
-        if (df := dfs.pop((k := sensor_pb2.ImageMetadata.__name__), None)) is not None:
+        if (df := dfs.pop((k := ImageMetadata.__name__), None)) is not None:
             dfs |= {
                 ".".join((k, *map(str, k_partition))): df_partition
                 for k_partition, df_partition in df.partition_by(

--- a/src/rbyte/io/yaak/metadata/message_iterator.py
+++ b/src/rbyte/io/yaak/metadata/message_iterator.py
@@ -9,7 +9,8 @@ from pydantic import InstanceOf, validate_call
 from structlog import get_logger
 from structlog.contextvars import bound_contextvars
 
-from rbyte.io.yaak.proto import can_pb2, sensor_pb2
+from rbyte.io.yaak.proto.can_pb2 import VehicleMotion, VehicleState
+from rbyte.io.yaak.proto.sensor_pb2 import DriveSessionInfo, Gnss, ImageMetadata
 
 logger = get_logger(__name__)
 
@@ -22,10 +23,11 @@ class YaakMetadataMessageIterator(Iterator[tuple[type[Message], bytes]]):
     """An iterator over a metadata file(-like object) producing messages."""
 
     MESSAGE_TYPES: ClassVar[dict[int, type[Message]]] = {
-        0: sensor_pb2.Gnss,
-        4: sensor_pb2.ImageMetadata,
-        7: can_pb2.VehicleMotion,
-        8: can_pb2.VehicleState,
+        0: Gnss,
+        4: ImageMetadata,
+        6: DriveSessionInfo,
+        7: VehicleMotion,
+        8: VehicleState,
     }
 
     FILE_HEADER_VERSION: int = 1

--- a/src/rbyte/viz/loggers/rerun_logger.py
+++ b/src/rbyte/viz/loggers/rerun_logger.py
@@ -3,10 +3,12 @@ from collections.abc import Callable, Iterable, Sequence
 from functools import cached_property
 from math import prod
 from typing import Annotated, Any, Literal, cast, override
+from uuid import UUID
 
 import rerun as rr
 import rerun.blueprint as rrb
 import torch
+import torch.nn.functional as F  # noqa: N812
 from cachetools import Cache, cachedmethod
 from einops import rearrange
 from hydra.utils import get_method
@@ -95,7 +97,9 @@ class RerunLogger(Logger[TensorDict | TensorClass]):
         self,
         *,
         application_id: str,
+        recording_id: str | UUID | None = None,
         recording_name: str | tuple[str, ...],
+        entity_path_format: str = "{}",
         schema: Schema,
         spawn: bool = True,
         port: int = 9876,
@@ -108,12 +112,14 @@ class RerunLogger(Logger[TensorDict | TensorClass]):
     ) -> None:
         super().__init__()
 
-        self._application_id: str = application_id
-        self._recording_name: str | tuple[str, ...] = recording_name
-        self._schema: Schema = schema
-        self._spawn: bool = spawn
-        self._port: int = port
-        self._blueprint: rrb.BlueprintLike | None = blueprint
+        self._application_id = application_id
+        self._recording_id = recording_id
+        self._recording_name = recording_name
+        self._entity_path_format = entity_path_format
+        self._schema = schema
+        self._spawn = spawn
+        self._port = port
+        self._blueprint: rrb.BlueprintLike | None = blueprint  # ty:ignore[invalid-assignment]
 
         self._recordings: Cache[str, rr.RecordingStream] = Cache(maxsize=math.inf)
 
@@ -121,16 +127,25 @@ class RerunLogger(Logger[TensorDict | TensorClass]):
     def recordings(self) -> Cache[str, rr.RecordingStream]:
         return self._recordings
 
+    def _entity_path(self, path: str) -> str:
+        return self._entity_path_format.format(path)
+
     @cachedmethod(lambda self: self._recordings)
     def _get_recording(self, name: str) -> rr.RecordingStream:
-        recording = rr.RecordingStream(self._application_id)
+        recording = rr.RecordingStream(
+            application_id=self._application_id, recording_id=self._recording_id
+        )
         if self._spawn:
             recording.spawn(port=self._port, default_blueprint=self._blueprint)
 
         recording.send_recording_name(name)
 
         for path, items in self._schema.static.items():
-            recording.log(path, *(item.instantiate() for item in items), static=True)
+            recording.log(
+                self._entity_path(path),
+                *(item.instantiate() for item in items),
+                static=True,
+            )
 
         return recording
 
@@ -146,7 +161,7 @@ class RerunLogger(Logger[TensorDict | TensorClass]):
 
         for timeline, config in self._schema.time_columns.items():
             kwargs: dict[str, Any] = {}
-            for k, k_data in config.model_extra.items():  # ty:ignore[possibly-missing-attribute]
+            for k, k_data in config.model_extra.items():  # ty:ignore[unresolved-attribute]
                 v = (
                     torch
                     .atleast_1d(data[*k_data][column_indices].flatten())  # ty: ignore[invalid-argument-type]
@@ -158,10 +173,10 @@ class RerunLogger(Logger[TensorDict | TensorClass]):
             yield config.instantiate(timeline=timeline, **kwargs)
 
     @classmethod
-    def _build_component_columns(  # noqa: C901, PLR0912
+    def _build_component_columns(  # noqa: C901, PLR0912, PLR0915
         cls, config: ComponentColumnSchemaItem, data: TensorDict
     ) -> rr.ComponentColumnList:
-        kwargs = TensorDict({k: data[*v] for k, v in config.model_extra.items()})  # ty: ignore[possibly-missing-attribute]
+        kwargs = TensorDict({k: data[*v] for k, v in config.model_extra.items()})  # ty:ignore[unresolved-attribute]
         lengths: list[int] | None = None
 
         with bound_contextvars(target=config.target):
@@ -219,12 +234,39 @@ class RerunLogger(Logger[TensorDict | TensorClass]):
                             raise NotImplementedError(msg)
 
                 case rr.Points3D.columns:
+                    # NOTE: pad (x, y) points to (x, y, 0) so we get ViewCoordinates
+                    # (unavailable for 2D views: https://github.com/rerun-io/rerun/issues/1387)
                     match tensor := kwargs.get(key := "positions"):
+                        case Tensor(shape=(2,)):
+                            kwargs[key] = F.pad(tensor, (0, 1), value=0)
+
                         case Tensor(shape=(3,)):
                             pass
 
+                        case Tensor(shape=(*batch_dims, n, 2)):
+                            kwargs[key] = rearrange(
+                                F.pad(tensor, (0, 1), value=0), "... n d -> (... n) d"
+                            )
+                            lengths = [n] * prod(batch_dims)
+
                         case Tensor(shape=(*batch_dims, n, 3)):
                             kwargs[key] = rearrange(tensor, "... n d -> (... n) d")
+                            lengths = [n] * prod(batch_dims)
+
+                        case _:
+                            logger.error(
+                                (msg := "shape not supported"),
+                                key=key,
+                                shape=tensor.shape,
+                            )
+                            raise NotImplementedError(msg)
+
+                case rr.GeoPoints.columns:
+                    match tensor := kwargs.get(key := "positions"):
+                        case Tensor(shape=(2,)):
+                            pass
+
+                        case Tensor(shape=(*batch_dims, n, 2)):
                             lengths = [n] * prod(batch_dims)
 
                         case _:
@@ -257,10 +299,7 @@ class RerunLogger(Logger[TensorDict | TensorClass]):
     def _log(self, data: TensorDict) -> None:
         time_columns: dict[Indices | None, list[rr.TimeColumn]] = {}
 
-        for (
-            entity_path,
-            component_column_configs,
-        ) in self._schema.component_columns.items():
+        for path, component_column_configs in self._schema.component_columns.items():
             for column_config in component_column_configs:
                 component_columns = self._build_component_columns(column_config, data)
 
@@ -270,7 +309,7 @@ class RerunLogger(Logger[TensorDict | TensorClass]):
                     )
 
                 rr.send_columns(
-                    entity_path=entity_path,
+                    entity_path=self._entity_path(path),
                     indexes=time_columns[indices],
                     columns=component_columns,
                 )

--- a/src/rbyte/viz/loggers/rerun_logger.py
+++ b/src/rbyte/viz/loggers/rerun_logger.py
@@ -267,6 +267,7 @@ class RerunLogger(Logger[TensorDict | TensorClass]):
                             pass
 
                         case Tensor(shape=(*batch_dims, n, 2)):
+                            kwargs[key] = rearrange(tensor, "... n d -> (... n) d")
                             lengths = [n] * prod(batch_dims)
 
                         case _:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -405,7 +405,7 @@ WHERE len("meta/ImageMetadata.cam_front_left/frame_idx") == 6
                     ],  # ty:ignore[unknown-argument]
                 )
                 for input_id in drive_queries
-            },
+            },  # ty:ignore[invalid-argument-type]
         )
         for camera in cameras
     }

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -51,7 +51,7 @@ def test_yaak_dataset(dataset: Dataset) -> None:
 
             assert waypoints_normalized.shape[2:] == (10, 2), "invalid waypoints shape"
 
-            assert not (waypoints_normalized == 0.0).all(), "waypoints are all zero"
+            assert not (waypoints_normalized == 0.0).all(), "waypoints are all zero"  # noqa: RUF069
 
             atol_relative = 1
             relative_distances = torch.linalg.norm(
@@ -60,7 +60,9 @@ def test_yaak_dataset(dataset: Dataset) -> None:
 
             # since we duplicate waypoints at the end of the ride
             relative_distances = torch.where(
-                relative_distances != 0.0, relative_distances, 10.0
+                relative_distances != 0.0,  # noqa: RUF069
+                relative_distances,
+                10.0,
             )
 
             assert torch.allclose(


### PR DESCRIPTION
Extend `RerunLogger` and `YaakMetadataMessageIterator` for validation vs https://github.com/yaak-ai/drahve/blob/nnstreamer/pipelines/replay/aligned.nu

- support logging `rr.GeoPoints` and `rr.Points3D` (w/ 2D->3D padding) and specifying `recording_id`/`entity_path_format`
- extract `DriveSessionInfo` metadata messages (for alignment on `session_timestamp`)
- bump `ruff`/`ty`