### PR TITLE
feat: thread-local dataset stream source cache

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777826146,
-        "narHash": "sha256-wQ/iN5Zp5VIa3ebBibijPnLyKhor+xEbDy4d0goa9Zs=",
+        "lastModified": 1778794387,
+        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "73c703c22422b8951895a960959dbbaca7296492",
+        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
         "type": "github"
       },
       "original": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rbyte"
-version = "0.35.0"
+version = "0.36.0"
 description = "Multimodal PyTorch dataset library"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -29,7 +29,7 @@ dependencies = [
   "polars>=1.40.1",
   "pydantic>=2.13.3",
   "structlog>=25.5.0",
-  "tensordict>=0.11.0",  # https://github.com/pytorch/tensordict/issues/1440
+  "tensordict>=0.12.3",
   "torch",
   "torchdata>=0.11.0",
   "tqdm>=4.67.1",
@@ -50,10 +50,10 @@ hdf5 = ["h5py>=3.14.0"]
 jpeg = ["simplejpeg>=1.9.0"]
 mcap = ["mcap>=1.3.1", "mcap-protobuf-support>=0.5.4", "protobuf"]
 protos = ["grpcio-tools==1.71.0", "protoletariat>=3.3.10"]
-video = ["torchcodec>=0.10.0"]
+video = ["torchcodec>=0.12.0"]
 visualize = [
   "einops>=0.8.2",
-  "rerun-sdk[notebook]>=0.31.4",
+  "rerun-sdk[notebook]>=0.32.0",
 ]
 yaak = ["ptars==0.0.5", "protobuf"]
 
@@ -147,23 +147,3 @@ schema.strict = false
 
 [tool.ty.rules]
 unused-ignore-comment = "warn"
-
-[tool.uv.sources]
-torch = [
-  { index = "pytorch-cpu", marker = "sys_platform != 'linux'" },
-  { index = "pytorch-cu128", marker = "sys_platform == 'linux'" },
-]
-torchcodec = [
-  { index = "pytorch-cpu", marker = "sys_platform != 'linux'" },
-  { index = "pytorch-cu128", marker = "sys_platform == 'linux'" },
-]
-
-[[tool.uv.index]]
-name = "pytorch-cpu"
-url = "https://download.pytorch.org/whl/cpu"
-explicit = true
-
-[[tool.uv.index]]
-name = "pytorch-cu128"
-url = "https://download.pytorch.org/whl/cu128"
-explicit = true

--- a/src/rbyte/dataset.py
+++ b/src/rbyte/dataset.py
@@ -1,14 +1,13 @@
-import math
 from collections.abc import Sequence
 from concurrent.futures import Executor
 from enum import StrEnum, auto, unique
 from io import BytesIO
+from threading import local
 from typing import TYPE_CHECKING, Annotated, Any, Self, override
 
 import checkedframe as cf
 import polars as pl
 import torch
-from cachetools import Cache, cachedmethod
 from optree import tree_map
 from pipefunc.map import load_outputs
 from pydantic import (
@@ -36,6 +35,10 @@ if TYPE_CHECKING:
 __all__ = ["Dataset"]
 
 logger = get_logger(__name__)
+
+
+class _StreamSourceThreadCache(local):
+    sources: dict[tuple[str, str], TensorSource]
 
 
 @unique
@@ -82,7 +85,7 @@ class Dataset(TorchDataset[Batch]):  # noqa: PLW1641
         self._streams = streams
 
         if self._streams is not None:
-            self._stream_source_cache = Cache(maxsize=math.inf)
+            self._stream_source_cache = _StreamSourceThreadCache()
 
     @classmethod
     @validate_call
@@ -171,13 +174,30 @@ class Dataset(TorchDataset[Batch]):  # noqa: PLW1641
 
         return Batch(data=data, meta=meta).auto_batch_size_(1)
 
-    @cachedmethod(lambda self: self._stream_source_cache)
     def _get_source(self, stream_id: str, input_id: str) -> TensorSource:
-        if self.streams is None:
+        streams = self.streams
+        if streams is None:
             msg = "streams not specified"
             raise RuntimeError(msg)
 
-        return self.streams[stream_id].sources[input_id].instantiate()
+        key = (stream_id, input_id)
+        cache = self._get_stream_source_cache()
+
+        try:
+            return cache[key]
+        except KeyError:
+            source = streams[stream_id].sources[input_id].instantiate()
+            cache[key] = source
+
+            return source
+
+    def _get_stream_source_cache(self) -> dict[tuple[str, str], TensorSource]:
+        try:
+            return self._stream_source_cache.sources
+        except AttributeError:
+            self._stream_source_cache.sources = {}
+
+            return self._stream_source_cache.sources
 
     @classmethod
     def _build_samples(

--- a/src/rbyte/io/video/torchcodec_source.py
+++ b/src/rbyte/io/video/torchcodec_source.py
@@ -27,7 +27,7 @@ class SeekMode(StrEnum):
 
 @unique
 class CudaBackend(StrEnum):
-    BETA = auto()
+    NVDEC = auto()
     FFMPEG = auto()
 
 
@@ -52,16 +52,12 @@ class TorchCodecFrameSource(TensorSource[int]):
     ) -> None:
         super().__init__()
 
-        if cuda_backend is None:
-            match device, torch.get_default_device():
-                case (torch.device(type="cuda"), _) | (None, torch.device(type="cuda")):
-                    cuda_backend = CudaBackend.BETA
-
-                case _:
-                    cuda_backend = CudaBackend.FFMPEG
-
         with (
-            set_cuda_backend(cuda_backend),
+            (
+                nullcontext()
+                if cuda_backend is None
+                else set_cuda_backend(cuda_backend.value)
+            ),
             (
                 nullcontext()
                 if custom_frame_mappings is None

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -6,19 +6,48 @@ from rbyte import Dataset
 from rbyte.dataloader import TorchDataNodeDataLoader, collate_identity
 
 
-@pytest.mark.parametrize("dataset", [lf("yaak_dataset")])
-def test_dataloaders(dataset: Dataset) -> None:
-    kwargs = {
-        "dataset": dataset,
+@pytest.fixture
+def common_kwargs() -> dict[str, object]:
+    return {
         "batch_size": 2,
         "shuffle": False,
         "collate_fn": collate_identity,
-        "num_workers": 1,
-        "multiprocessing_context": "forkserver",
+        "num_workers": 2,
     }
 
-    torch_dataloader = DataLoader(**kwargs)  # ty: ignore[invalid-argument-type]
-    torchdata_dataloader = TorchDataNodeDataLoader(method="process", **kwargs)  # ty: ignore[invalid-argument-type]
 
+@pytest.fixture
+def torch_dataloader(dataset: Dataset, common_kwargs: dict[str, object]) -> DataLoader:
+    return DataLoader(
+        dataset=dataset,
+        multiprocessing_context="forkserver",
+        **common_kwargs,  # ty:ignore[invalid-argument-type]
+    )
+
+
+@pytest.fixture(params=[pytest.param("process"), pytest.param("thread")])
+def torchdata_dataloader(
+    dataset: Dataset, request: pytest.FixtureRequest, common_kwargs: dict[str, object]
+) -> TorchDataNodeDataLoader:
+    match request.param:
+        case "process":
+            kwargs = {"multiprocessing_context": "forkserver", "method": "process"}
+
+        case "thread":
+            kwargs = {"method": "thread"}
+
+        case _:
+            raise RuntimeError
+
+    return TorchDataNodeDataLoader(
+        dataset=dataset,
+        **(common_kwargs | kwargs),  # ty:ignore[invalid-argument-type]
+    )
+
+
+@pytest.mark.parametrize("dataset", [lf("yaak_dataset")])
+def test_dataloaders(
+    torch_dataloader: DataLoader, torchdata_dataloader: TorchDataNodeDataLoader
+) -> None:
     for left, right in zip(torch_dataloader, torchdata_dataloader, strict=True):
         assert (left == right).all()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,19 +1,37 @@
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
 import dill  # noqa: S403
 import more_itertools as mit
+import polars as pl
 import pytest
 import torch
 from pytest_lazy_fixtures import lf
 from structlog import get_logger
+from tensordict import TensorDict
 from torch import Tensor
 
 from rbyte import Dataset
+from rbyte.config import HydraConfig, StreamConfig
 
 logger = get_logger(__name__)
+
+
+class _CountingTensorSource:
+    instances = 0
+
+    def __init__(self) -> None:
+        type(self).instances += 1
+        self.instance_id = type(self).instances
+
+    def __getitem__(self, indexes: int | Sequence[int]) -> Tensor:
+        return torch.as_tensor(indexes)
+
+    def __len__(self) -> int:
+        return 1
 
 
 @pytest.mark.parametrize("dataset", [lf("yaak_dataset"), lf("yaak_dataset_pydantic")])
@@ -268,6 +286,37 @@ def test_save_and_load(dataset: Dataset, tmp_path: Path) -> None:
 )
 def test_pickle(dataset: Dataset) -> None:
     assert dill.pickles(dataset, exact=True, safe=True)
+
+
+def test_stream_source_cache_is_thread_local() -> None:
+    _CountingTensorSource.instances = 0
+    dataset = Dataset(
+        data=TensorDict({"stream": torch.tensor([0])}, batch_size=[1]),
+        meta=pl.DataFrame({"input_id": ["input"]}),
+        streams={
+            "stream": StreamConfig(
+                index="stream",
+                sources={"input": HydraConfig(target=_CountingTensorSource)},
+            )
+        },
+    )
+
+    main_first = dataset._get_source("stream", "input")  # noqa: SLF001
+    main_second = dataset._get_source("stream", "input")  # noqa: SLF001
+
+    def get_worker_sources() -> tuple[object, object]:
+        return (
+            dataset._get_source("stream", "input"),  # noqa: SLF001
+            dataset._get_source("stream", "input"),  # noqa: SLF001
+        )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        worker_first, worker_second = executor.submit(get_worker_sources).result()
+
+    assert main_first is main_second
+    assert worker_first is worker_second
+    assert worker_first is not main_first
+    assert _CountingTensorSource.instances == 2  # noqa: PLR2004
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
ctx: `torchcodec`-based `rbyte.io.TorchCodecFrameSource` can't be safely shared among threads, e.g. when an `rbyte.Dataset` is used via a `rbyte.dataloader.TorchDataNodeDataLoader(..., method="thread")`

generally speaking we probably can't assume thread safety for any source

changes:
- make dataset stream source cache thread-local
- bump torchcodec, tensordict
- add tests for dataset stream source cache and multithreaded dataloader