### PR TITLE
chore: bump torchcodec>=0.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rbyte"
-version = "0.36.0"
+version = "0.36.1"
 description = "Multimodal PyTorch dataset library"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -50,7 +50,7 @@ hdf5 = ["h5py>=3.14.0"]
 jpeg = ["simplejpeg>=1.9.0"]
 mcap = ["mcap>=1.3.1", "mcap-protobuf-support>=0.5.4", "protobuf"]
 protos = ["grpcio-tools==1.71.0", "protoletariat>=3.3.10"]
-video = ["torchcodec>=0.12.0"]
+video = ["torchcodec>=0.13.0"]
 visualize = [
   "einops>=0.8.2",
   "rerun-sdk[notebook]>=0.32.0",


### PR DESCRIPTION
https://github.com/meta-pytorch/torchcodec/releases/tag/v0.13.0 for pypi cuda wheels