### PR TITLE
feat: batch/dedup stream source reads in `Dataset.get_batch`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,49 +10,43 @@ on:
   workflow_dispatch:
 
 env:
-  UV_NO_SOURCES: "1"
+  UV_CACHE_DIR: /tmp/.uv-cache
 
 jobs:
   ci:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: nix develop -c bash --noprofile --norc -eo pipefail {0}
+
     steps:
-      - name: setup ssh
-        uses: webfactory/ssh-agent@v0.9.1
+      - uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.YAAK_IDL_REPO_SSH_KEY }}
 
-      - name: checkout
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: false
           lfs: true
 
-      - name: setup just
-        uses: extractions/setup-just@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flake-checker-action@main
 
-      - name: setup uv
-        uses: astral-sh/setup-uv@v7
+      - run: uv lock
+
+      - uses: actions/cache@v5
         with:
-          version: "latest"
-          enable-cache: true
+          path: /tmp/.uv-cache
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+            uv-${{ runner.os }}
 
       - run: uv sync --all-extras --group check --group test
       - run: just build
       - run: just check
-
-      - name: git lfs checkout
-        run: git lfs checkout
-
-      - name: setup ytt
-        uses: carvel-dev/setup-action@v2
-        with:
-          only: ytt
-
-      - name: setup nu
-        uses: hustcer/setup-nu@v3
-
-      - name: install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
-
+      - run: git lfs checkout
       - run: just test
+      - run: uv cache prune --ci

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ uv.lock
 
 # env
 .direnv
-.envrc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,14 +16,14 @@ repos:
       - id: pyupgrade
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.14
     hooks:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/tombi-toml/tombi-pre-commit
-    rev: v0.10.2
+    rev: v1.0.0
     hooks:
       - id: tombi-format
       - id: tombi-lint

--- a/config/_templates/benchmark_dataloader.yaml
+++ b/config/_templates/benchmark_dataloader.yaml
@@ -8,9 +8,8 @@ dataloader:
   dataset: ${dataset}
   shuffle: false
   batch_size: 64
-  num_workers: 1
+  num_workers: ???
   collate_fn:
-    _target_: rbyte.types.Batch.to_dict
-    _partial_: true
-  pin_memory: true
+    _target_: hydra.utils.get_method
+    path: rbyte.dataloader.collate_identity
   multiprocessing_context: forkserver

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778794387,
-        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
+        "lastModified": 1779694939,
+        "narHash": "sha256-Ly4j75O8ICaSQx3uxPnwk2x7PMF0XQvn5r0c3yBA7FI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
+        "rev": "f9d8b65950353691ab56561e7c73d2e1063d810b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,26 @@
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        python = pkgs.python312;
+        ffmpeg =
+          if pkgs.stdenv.isLinux then
+            pkgs.ffmpeg_8-headless.override {
+              withHeadlessDeps = false;
+              buildFfmpeg = true;
+              buildFfprobe = true;
+              buildAvcodec = true;
+              buildAvdevice = true;
+              buildAvfilter = true;
+              buildAvformat = true;
+              buildAvutil = true;
+              buildSwresample = true;
+              buildSwscale = true;
+              withPixelutils = true;
+              withHardcodedTables = true;
+              withSafeBitstreamReader = true;
+            }
+          else
+            pkgs.ffmpeg-headless;
       in
       {
         devShells.default =
@@ -22,15 +42,26 @@
               uv
               ytt
               just
+              prek
               skim
-              ffmpeg-headless
+              python
+              ffmpeg
             ];
 
-            shellHook = lib.strings.concatLines [
-              (lib.optionalString stdenv.isDarwin "export DYLD_FALLBACK_LIBRARY_PATH=${
-                lib.makeLibraryPath [ ffmpeg-headless ]
-              }")
-            ];
+            shellHook =
+              let
+                libraryPath = lib.makeLibraryPath [
+                  ffmpeg
+                  stdenv.cc.cc.lib
+                ];
+                libraryPathEnvVar = if stdenv.isDarwin then "DYLD_FALLBACK_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+              in
+              lib.strings.concatLines [
+                "export UV_PYTHON=${python}/bin/python"
+                "export UV_NO_MANAGED_PYTHON=1"
+                "export UV_PYTHON_DOWNLOADS=never"
+                "export ${libraryPathEnvVar}=${libraryPath}\${${libraryPathEnvVar}:+:${"$"}${libraryPathEnvVar}}"
+              ];
           };
       }
     );

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ sync:
 setup: sync
     git submodule update --init --recursive --force --remote
     git lfs pull
-    uvx prek@latest install --overwrite
+    prek install --overwrite
 
 build:
     uv build
@@ -32,7 +32,7 @@ check:
     uv run ty check
 
 prek *ARGS: build
-    uvx prek@latest --all-files {{ ARGS }}
+    prek --all-files {{ ARGS }}
 
 [script]
 generate-config:

--- a/justfile
+++ b/justfile
@@ -1,3 +1,7 @@
+set shell := ["nu", "-c"]
+set script-interpreter := ["nu"]
+set lazy
+
 export PYTHONOPTIMIZE := "1"
 export HATCH_BUILD_CLEAN := "1"
 export HYDRA_FULL_ERROR := "1"
@@ -30,14 +34,17 @@ check:
 prek *ARGS: build
     uvx prek@latest --all-files {{ ARGS }}
 
+[script]
 generate-config:
-    ytt --file {{ justfile_directory() }}/config/_templates \
-        --output-files {{ justfile_directory() }}/config \
-        --output yaml \
+    (
+    ytt --file {{ justfile_directory() }}/config/_templates
+        --output-files {{ justfile_directory() }}/config
+        --output yaml
         --strict
+    )
 
+[script]
 generate-test-data-yaak-mp4-frame-mappings:
-    #!/usr/bin/env nu
     ls -f tests/data/yaak/**/*.mp4 | get name | par-each { |video|
         let output = $"($video).frames.json";
         print $"creating: ($output)";
@@ -50,24 +57,24 @@ test *ARGS: build generate-config generate-test-data-yaak-mp4-frame-mappings
 notebook FILE *ARGS: sync generate-config
     uv run --all-extras --with=jupyter,jupyterlab-vim,rerun-notebook jupyter lab {{ FILE }} {{ ARGS }}
 
-[group('scripts')]
+[script]
 _visualize *ARGS:
-    uv run rbyte-visualize \
-        --config-path {{ justfile_directory() }}/config \
-        --config-name visualize.yaml \
-        hydra/hydra_logging=disabled \
-        hydra/job_logging=disabled \
+    (
+    uv run rbyte-visualize
+        --config-path {{ justfile_directory() }}/config
+        --config-name visualize.yaml
+        hydra/hydra_logging=disabled
+        hydra/job_logging=disabled
         {{ ARGS }}
+    )
 
-[group('scripts')]
+[script]
 visualize dataset *ARGS: generate-config
-    #!/usr/bin/env nu
     match "{{ dataset }}" {
         "yaak" => { just generate-test-data-yaak-mp4-frame-mappings }
     }
     just _visualize dataset={{ dataset }} ++data_dir={{ justfile_directory() }}/tests/data/{{ dataset }} {{ ARGS }}
 
-[group('scripts')]
 visualize-all: generate-config
     just visualize yaak
     just visualize zod batch_size=1
@@ -75,13 +82,16 @@ visualize-all: generate-config
     just visualize nuscenes
     just visualize carla_garage
 
+[script]
 benchmark-dataloader *ARGS: generate-config
-    uv run rbyte-benchmark-dataloader \
-        --config-path {{ justfile_directory() }}/config \
-        --config-name benchmark_dataloader.yaml \
-        hydra/hydra_logging=disabled \
-        hydra/job_logging=disabled \
+    (
+    uv run rbyte-benchmark-dataloader
+        --config-path {{ justfile_directory() }}/config
+        --config-name benchmark_dataloader.yaml
+        hydra/hydra_logging=disabled
+        hydra/job_logging=disabled
         {{ ARGS }}
+    )
 
 rerun *ARGS:
     uv run rerun --serve-web {{ ARGS }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "rbyte"
-version = "0.36.1"
+version = "0.37.0"
 description = "Multimodal PyTorch dataset library"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
-license = { text = "Apache-2.0" }
+license-files = ["LICENSE.txt"]
 authors = [{ name = "Evgenii Gorchakov", email = "evgenii@yaak.ai" }]
 maintainers = [{ name = "Evgenii Gorchakov", email = "evgenii@yaak.ai" }]
 classifiers = [
@@ -22,14 +22,14 @@ dependencies = [
   "duckdb>=1.5.2",
   "hydra-core>=1.3.2",
   "makefun>=1.16.0",
-  "more-itertools>=10.8.0",
+  "more-itertools>=11.0.2",
   "numpy",
   "optree>=0.18.0",
   "pipefunc[autodoc]>=0.90.2",
   "polars>=1.40.1",
-  "pydantic>=2.13.3",
+  "pydantic>=2.13.4",
   "structlog>=25.5.0",
-  "tensordict>=0.12.3",
+  "tensordict>=0.12.4",
   "torch",
   "torchdata>=0.11.0",
   "tqdm>=4.67.1",
@@ -53,7 +53,7 @@ protos = ["grpcio-tools==1.71.0", "protoletariat>=3.3.10"]
 video = ["torchcodec>=0.13.0"]
 visualize = [
   "einops>=0.8.2",
-  "rerun-sdk[notebook]>=0.32.0",
+  "rerun-sdk[notebook]>=0.32.2",
 ]
 yaak = ["ptars==0.0.5", "protobuf"]
 
@@ -71,8 +71,8 @@ dev = [
   "wat-inspector>=0.4.3",
 ]
 check = [
-  "ruff>=0.15.12",
-  "ty>=0.0.34",
+  "ruff>=0.15.14",
+  "ty>=0.0.39",
 ]
 test = [
   "dill>=0.4.1",

--- a/src/rbyte/dataset.py
+++ b/src/rbyte/dataset.py
@@ -2,12 +2,13 @@ from collections.abc import Sequence
 from concurrent.futures import Executor
 from enum import StrEnum, auto, unique
 from io import BytesIO
+from operator import itemgetter
 from threading import local
 from typing import TYPE_CHECKING, Annotated, Any, Self, override
 
 import checkedframe as cf
+import more_itertools as mit
 import polars as pl
-import torch
 from optree import tree_map
 from pipefunc.map import load_outputs
 from pydantic import (
@@ -31,6 +32,7 @@ from rbyte.types import Batch, BatchMeta, TensorSource
 
 if TYPE_CHECKING:
     from pipefunc._pipeline._types import OUTPUT_TYPE
+    from torch import Tensor
 
 __all__ = ["Dataset"]
 
@@ -137,25 +139,51 @@ class Dataset(TorchDataset[Batch]):  # noqa: PLW1641
         include_streams: bool | None = None,
         include_meta: bool = True,
     ) -> Batch:
-        data = self.data[index]  # ty: ignore[invalid-argument-type]
-        meta = self.meta[index]
+        batch_data: TensorDict = self.data[index]  # ty: ignore[invalid-argument-type, invalid-assignment]
+        meta: pl.DataFrame = self.meta[index]
 
         match include_streams, self.streams:
             case None | True, dict():
-                stream_data = {stream_id: [] for stream_id in self.streams}  # ty: ignore[not-iterable]
+                stream_data = {}
 
-                for sample, input_id in zip(data, meta["input_id"], strict=True):
-                    for stream_id, stream_config in self.streams.items():  # ty:ignore[unresolved-attribute]
-                        stream_index = sample[stream_config.index].tolist()
+                for stream_id, stream_config in self.streams.items():  # ty:ignore[unresolved-attribute]
+                    stream_indexes = list(
+                        zip(
+                            meta["input_id"],
+                            batch_data[stream_config.index].tolist(),
+                            strict=True,
+                        )
+                    )
+
+                    grouped_stream_indexes = mit.map_reduce(
+                        stream_indexes, keyfunc=itemgetter(0), valuefunc=itemgetter(1)
+                    )
+
+                    stream_items: dict[str, dict[int, Tensor]] = {}
+                    for input_id, group_indexes in grouped_stream_indexes.items():
+                        unique_indexes = sorted(set(mit.collapse(group_indexes)))
                         source = self._get_source(stream_id, input_id)
-                        stream_data[stream_id].append(source[stream_index])
+                        source_items = source[unique_indexes]
 
-                stream_data = {k: torch.stack(v) for k, v in stream_data.items()}
+                        stream_items[input_id] = dict(
+                            zip(unique_indexes, source_items, strict=True)
+                        )
 
-                if data.is_locked:  # ty:ignore[unresolved-attribute]
-                    data = data.clone(recurse=True)  # ty: ignore[unknown-argument]
+                    stream_batches = []
+                    for input_id, input_stream_index in stream_indexes:
+                        input_stream_items = stream_items[input_id]
+                        stream_batches.append(
+                            [input_stream_items[i] for i in input_stream_index]
+                            if isinstance(input_stream_index, Sequence)
+                            else input_stream_items[input_stream_index]
+                        )
 
-                data = data.update(stream_data, inplace=False)  # ty:ignore[unresolved-attribute]
+                    stream_data[stream_id] = stream_batches
+
+                if batch_data.is_locked:
+                    batch_data = batch_data.clone(recurse=True)
+
+                batch_data = batch_data.update(stream_data, inplace=False)
 
             case True, None:
                 msg = "`include_streams` is True but no streams specified"
@@ -164,7 +192,7 @@ class Dataset(TorchDataset[Batch]):  # noqa: PLW1641
             case _:
                 pass
 
-        meta = (
+        batch_meta = (
             BatchMeta.from_dict({
                 k: NonTensorStack(*v) for k, v in meta.to_dict().items()
             })
@@ -172,7 +200,7 @@ class Dataset(TorchDataset[Batch]):  # noqa: PLW1641
             else None
         )
 
-        return Batch(data=data, meta=meta).auto_batch_size_(1)
+        return Batch(data=batch_data, meta=batch_meta).auto_batch_size_(1)
 
     def _get_source(self, stream_id: str, input_id: str) -> TensorSource:
         streams = self.streams

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import ClassVar, cast
 
 import dill  # noqa: S403
 import more_itertools as mit
@@ -22,16 +22,59 @@ logger = get_logger(__name__)
 
 class _CountingTensorSource:
     instances = 0
+    calls: ClassVar[list[int | list[int]]] = []
 
     def __init__(self) -> None:
         type(self).instances += 1
         self.instance_id = type(self).instances
 
     def __getitem__(self, indexes: int | Sequence[int]) -> Tensor:
+        call = list(indexes) if isinstance(indexes, Sequence) else indexes
+        type(self).calls.append(call)  # ty:ignore[invalid-argument-type]
+
         return torch.as_tensor(indexes)
 
     def __len__(self) -> int:
         return 1
+
+
+def test_get_batch_deduplicates_stream_source_indexes() -> None:
+    _CountingTensorSource.instances = 0
+    _CountingTensorSource.calls = []
+    dataset = Dataset(
+        data=TensorDict({"stream": torch.tensor([2, 2, 3, 2])}, batch_size=[4]),
+        meta=pl.DataFrame({"input_id": ["A", "A", "B", "A"]}),
+        streams={
+            "stream": StreamConfig(
+                index="stream",
+                sources={
+                    "A": HydraConfig(target=_CountingTensorSource),
+                    "B": HydraConfig(target=_CountingTensorSource),
+                },
+            )
+        },
+    )
+
+    index = [0, 1, 2, 3]
+    match (batch := dataset.get_batch(index)).to_dict():
+        case {
+            "data": {"stream": Tensor(shape=[4], data=data), **data_rest},
+            "meta": {"input_id": ["A", "A", "B", "A"], **meta_rest},
+            **batch_rest,
+        } if data.tolist() == [2, 2, 3, 2] and not any((
+            batch_rest,
+            data_rest,
+            meta_rest,
+        )):
+            pass
+
+        case _:
+            logger.error(msg := "invalid batch structure", batch=batch)
+
+            raise AssertionError(msg)
+
+    assert _CountingTensorSource.calls == [[2], [3]]
+    assert _CountingTensorSource.instances == 2  # noqa: PLR2004
 
 
 @pytest.mark.parametrize("dataset", [lf("yaak_dataset"), lf("yaak_dataset_pydantic")])
@@ -290,6 +333,7 @@ def test_pickle(dataset: Dataset) -> None:
 
 def test_stream_source_cache_is_thread_local() -> None:
     _CountingTensorSource.instances = 0
+    _CountingTensorSource.calls = []
     dataset = Dataset(
         data=TensorDict({"stream": torch.tensor([0])}, batch_size=[1]),
         meta=pl.DataFrame({"input_id": ["input"]}),


### PR DESCRIPTION
why: avoid duplicate reading/decoding work case of high degree of source index overlap among samples within a single batch 

changes:
- batch stream reads by `(stream_id, input_id)` in `Dataset.get_batch`
- dedup requested stream indexes before calling `TensorSource.__getitem__` then scatter them back to preserve order
- add `test_get_batch_deduplicates_stream_source_indexes`
- update dataloader benchmarking config
- expand `flake.nix` and nixify CI
- clean up and nu-ify `justfile`
- unignore and add `.envrc`