### PR TITLE
fix: shard TorchDataNodeDataLoader via DistributedSampler under DDP

### DIFF
--- a/src/rbyte/dataloader.py
+++ b/src/rbyte/dataloader.py
@@ -118,7 +118,7 @@ class TorchDataNodeDataLoader[T](Iterable[T], Sized):
                 )
                 raise ValueError(msg)
             self._distributed_sampler = DistributedSampler(
-                self._dataset,  # pyright: ignore[reportArgumentType]
+                self._dataset,  # pyright: ignore[reportArgumentType]  # ty: ignore[invalid-argument-type]
                 shuffle=bool(self._shuffle),
                 drop_last=self._drop_last,
                 seed=self._seed,
@@ -133,7 +133,9 @@ class TorchDataNodeDataLoader[T](Iterable[T], Sized):
             )
 
         self._sampler = BatchSampler(
-            sampler, batch_size=self._batch_size, drop_last=self._drop_last
+            sampler,  # ty: ignore[invalid-argument-type]
+            batch_size=self._batch_size,
+            drop_last=self._drop_last,
         )
 
         node = tn.SamplerWrapper(self._sampler)
@@ -141,7 +143,7 @@ class TorchDataNodeDataLoader[T](Iterable[T], Sized):
             source=node,
             map_fn=MapAndCollate(self._dataset, self._collate_fn or default_collate),
             method=self._method,
-            **self._node_kwargs,  # pyright: ignore[reportArgumentType]
+            **self._node_kwargs,  # pyright: ignore[reportArgumentType]  # ty: ignore[invalid-argument-type]
         )
 
         if self._pin_memory:
@@ -149,7 +151,7 @@ class TorchDataNodeDataLoader[T](Iterable[T], Sized):
 
         node = tn.Prefetcher(
             node,
-            prefetch_factor=self._node_kwargs["num_workers"] * self._prefetch_factor,  # pyright: ignore[reportOperatorIssue]
+            prefetch_factor=self._node_kwargs["num_workers"] * self._prefetch_factor,  # pyright: ignore[reportOperatorIssue]  # ty: ignore[unsupported-operator]
         )
 
         self._loader = tn.Loader(node)

--- a/src/rbyte/dataloader.py
+++ b/src/rbyte/dataloader.py
@@ -1,11 +1,13 @@
 from collections.abc import Callable, Iterable, Sequence, Sized
 from typing import Any, Literal, Protocol, runtime_checkable
 
+import torch.distributed
 import torchdata.nodes as tn
 from pydantic import InstanceOf, PositiveInt, validate_call
 from torch import Generator
 from torch.utils.data import (
     BatchSampler,
+    DistributedSampler,
     RandomSampler,
     SequentialSampler,
     default_collate,
@@ -59,43 +61,125 @@ class TorchDataNodeDataLoader[T](Iterable[T], Sized):
         max_concurrent: int | None = None,
         snapshot_frequency: int = 1,
         prebatch: int | None = None,
+        seed: int = 0,
     ) -> None:
         self._dataset = dataset
+        self._batch_size = batch_size
+        self._shuffle = shuffle
+        self._drop_last = drop_last
+        self._generator = generator
+        self._seed = seed
+        self._method: Literal["thread", "process"] = method
+        self._collate_fn = collate_fn
+        self._pin_memory = pin_memory
+        self._pin_memory_device = pin_memory_device
+        self._prefetch_factor = prefetch_factor
+        self._node_kwargs = {
+            "num_workers": num_workers,
+            "in_order": in_order,
+            "multiprocessing_context": multiprocessing_context,
+            "max_concurrent": max_concurrent,
+            "snapshot_frequency": snapshot_frequency,
+            "prebatch": prebatch,
+        }
 
-        sampler = (
-            RandomSampler(dataset, generator=generator)
-            if shuffle
-            else SequentialSampler(dataset)
-        )
+        self._distributed_sampler: DistributedSampler[object] | None = None
+        self._sampler: BatchSampler | None = None
+        self._loader: tn.Loader[T] | None = None
+        self._built_distributed: bool | None = None
+
+    @staticmethod
+    def _distributed_now() -> bool:
+        return torch.distributed.is_available() and torch.distributed.is_initialized()
+
+    def _build(self) -> None:
+        """Build the sampler and node graph.
+
+        Deferred past ``__init__``: framework integrations (e.g. hydra +
+        pytorch-lightning) construct the loader before ``trainer.fit``
+        initializes the distributed process group, so the sharding decision
+        must be taken at first iteration. Without a ``DistributedSampler``,
+        every rank draws an identical (same-seed) sample sequence and the
+        all-reduced gradient degenerates to a single rank's.
+
+        Raises:
+            ValueError: if ``method='process'`` is configured under
+                distributed training (workers fork after CUDA init and
+                deadlock).
+        """
+        distributed = self._distributed_now()
+        self._built_distributed = distributed
+
+        if distributed:
+            if self._method != "thread":
+                msg = (
+                    "method='process' deadlocks under distributed training "
+                    "(fork after CUDA init); use method='thread'"
+                )
+                raise ValueError(msg)
+            self._distributed_sampler = DistributedSampler(
+                self._dataset,  # pyright: ignore[reportArgumentType]
+                shuffle=bool(self._shuffle),
+                drop_last=self._drop_last,
+                seed=self._seed,
+            )
+            sampler = self._distributed_sampler
+        else:
+            self._distributed_sampler = None
+            sampler = (  # pyright: ignore[reportAssignmentType]
+                RandomSampler(self._dataset, generator=self._generator)  # pyright: ignore[reportArgumentType]
+                if self._shuffle
+                else SequentialSampler(self._dataset)  # pyright: ignore[reportArgumentType]
+            )
 
         self._sampler = BatchSampler(
-            sampler, batch_size=batch_size, drop_last=drop_last
+            sampler, batch_size=self._batch_size, drop_last=self._drop_last
         )
 
         node = tn.SamplerWrapper(self._sampler)
         node = tn.ParallelMapper(
             source=node,
-            map_fn=MapAndCollate(dataset, collate_fn or default_collate),
-            num_workers=num_workers,
-            in_order=in_order,
-            method=method,
-            multiprocessing_context=multiprocessing_context,
-            max_concurrent=max_concurrent,
-            snapshot_frequency=snapshot_frequency,
-            prebatch=prebatch,
+            map_fn=MapAndCollate(self._dataset, self._collate_fn or default_collate),
+            method=self._method,
+            **self._node_kwargs,  # pyright: ignore[reportArgumentType]
         )
 
-        if pin_memory:
-            node = tn.PinMemory(node, pin_memory_device=pin_memory_device)
+        if self._pin_memory:
+            node = tn.PinMemory(node, pin_memory_device=self._pin_memory_device)
 
-        node = tn.Prefetcher(node, prefetch_factor=num_workers * prefetch_factor)
+        node = tn.Prefetcher(
+            node,
+            prefetch_factor=self._node_kwargs["num_workers"] * self._prefetch_factor,  # pyright: ignore[reportOperatorIssue]
+        )
 
         self._loader = tn.Loader(node)
 
+    def _ensure_built(self) -> None:
+        # rebuild if the process group appeared after a premature build —
+        # an unsharded graph under distributed training silently degenerates
+        # the effective batch to a single rank's
+        if (
+            self._loader is not None
+            and self._built_distributed is False
+            and self._distributed_now()
+        ):
+            self._loader = None
+        if self._loader is None:
+            self._build()
+
+    def set_epoch(self, epoch: int) -> None:
+        """Forward the epoch to the DistributedSampler for per-epoch reshuffling."""
+        if self._distributed_sampler is not None:
+            self._distributed_sampler.set_epoch(epoch)
+
     def __iter__(self) -> LoaderIterator[T]:
+        self._ensure_built()
+        assert self._loader is not None  # noqa: S101
         return iter(self._loader)
 
     def __len__(self) -> int:
+        self._ensure_built()
+        assert self._sampler is not None  # noqa: S101
         return len(self._sampler)
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -394,18 +394,18 @@ WHERE len("meta/ImageMetadata.cam_front_left/frame_idx") == 6
         camera: StreamConfig(
             index=f"meta/ImageMetadata.{camera}/frame_idx",
             sources={
-                input_id: HydraConfig(
+                input_id: HydraConfig(  # ty: ignore[missing-argument]
                     target=TorchCodecFrameSource,
-                    source=(data_dir / input_id / f"{camera}.pii.mp4").as_posix(),  # ty: ignore[unknown-argument]
+                    source=(data_dir / input_id / f"{camera}.pii.mp4").as_posix(),
                     custom_frame_mappings=(
                         data_dir / input_id / f"{camera}.pii.mp4.frames.json"
-                    ).as_posix(),  # ty:ignore[unknown-argument]
+                    ).as_posix(),
                     transforms=[
                         {"_target_": "torchcodec.transforms.Resize", "size": [324, 576]}
-                    ],  # ty:ignore[unknown-argument]
+                    ],
                 )
                 for input_id in drive_queries
-            },  # ty:ignore[invalid-argument-type]
+            },
         )
         for camera in cameras
     }

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -106,7 +106,7 @@ def test_rebuilds_if_group_appears_late(
     )
     # simulate a build that happened before the process group existed
     loader._built_distributed = False  # noqa: SLF001
-    loader._loader = object()  # noqa: SLF001
+    loader._loader = object()  # noqa: SLF001  # ty: ignore[invalid-assignment]
     assert len(loader) > 0
     assert loader._distributed_sampler is not None  # noqa: SLF001
 

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -1,4 +1,5 @@
 import pytest
+import torch.distributed as dist
 from pytest_lazy_fixtures import lf
 from torch.utils.data import DataLoader
 
@@ -51,3 +52,74 @@ def test_dataloaders(
 ) -> None:
     for left, right in zip(torch_dataloader, torchdata_dataloader, strict=True):
         assert (left == right).all()
+
+
+EXPECTED_EPOCH = 3
+
+
+@pytest.fixture
+def _gloo_process_group():  # noqa: ANN202
+    dist.init_process_group(
+        backend="gloo", init_method="tcp://127.0.0.1:29517", rank=0, world_size=1
+    )
+    yield
+    dist.destroy_process_group()
+
+
+def test_no_sharding_without_process_group(
+    yaak_dataset: Dataset, common_kwargs: dict[str, object]
+) -> None:
+    loader = TorchDataNodeDataLoader(
+        dataset=yaak_dataset,
+        method="thread",
+        **common_kwargs,  # ty:ignore[invalid-argument-type]
+    )
+    assert len(loader) > 0
+    assert loader._distributed_sampler is None  # noqa: SLF001
+
+
+@pytest.mark.usefixtures("_gloo_process_group")
+def test_shards_with_process_group(
+    yaak_dataset: Dataset, common_kwargs: dict[str, object]
+) -> None:
+    loader = TorchDataNodeDataLoader(
+        dataset=yaak_dataset,
+        method="thread",
+        **common_kwargs,  # ty:ignore[invalid-argument-type]
+    )
+    assert len(loader) > 0  # triggers the lazy build
+    sampler = loader._distributed_sampler  # noqa: SLF001
+    assert sampler is not None
+    assert sampler.num_replicas == 1
+    loader.set_epoch(EXPECTED_EPOCH)
+    assert sampler.epoch == EXPECTED_EPOCH
+
+
+@pytest.mark.usefixtures("_gloo_process_group")
+def test_rebuilds_if_group_appears_late(
+    yaak_dataset: Dataset, common_kwargs: dict[str, object]
+) -> None:
+    loader = TorchDataNodeDataLoader(
+        dataset=yaak_dataset,
+        method="thread",
+        **common_kwargs,  # ty:ignore[invalid-argument-type]
+    )
+    # simulate a build that happened before the process group existed
+    loader._built_distributed = False  # noqa: SLF001
+    loader._loader = object()  # noqa: SLF001
+    assert len(loader) > 0
+    assert loader._distributed_sampler is not None  # noqa: SLF001
+
+
+@pytest.mark.usefixtures("_gloo_process_group")
+def test_process_method_rejected_under_ddp(
+    yaak_dataset: Dataset, common_kwargs: dict[str, object]
+) -> None:
+    loader = TorchDataNodeDataLoader(
+        dataset=yaak_dataset,
+        method="process",
+        multiprocessing_context="forkserver",
+        **common_kwargs,  # ty:ignore[invalid-argument-type]
+    )
+    with pytest.raises(ValueError, match="deadlocks under distributed"):
+        len(loader)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -48,8 +48,8 @@ def test_get_batch_deduplicates_stream_source_indexes() -> None:
             "stream": StreamConfig(
                 index="stream",
                 sources={
-                    "A": HydraConfig(target=_CountingTensorSource),
-                    "B": HydraConfig(target=_CountingTensorSource),
+                    "A": HydraConfig(target=_CountingTensorSource),  # ty: ignore[missing-argument]
+                    "B": HydraConfig(target=_CountingTensorSource),  # ty: ignore[missing-argument]
                 },
             )
         },
@@ -340,7 +340,7 @@ def test_stream_source_cache_is_thread_local() -> None:
         streams={
             "stream": StreamConfig(
                 index="stream",
-                sources={"input": HydraConfig(target=_CountingTensorSource)},
+                sources={"input": HydraConfig(target=_CountingTensorSource)},  # ty: ignore[missing-argument]
             )
         },
     )


### PR DESCRIPTION
## Problem

`TorchDataNodeDataLoader` hard-codes `RandomSampler` and is not a `torch.utils.data.DataLoader`, so pytorch-lightning cannot inject a `DistributedSampler`. Under `trainer.devices>1`, Lightning seeds all ranks identically → **every rank draws the same sample sequence**. The all-reduced gradient degenerates to a single rank's: N× the compute for an unchanged effective batch — silently.

We hit this in rmind DDP training (yaak-ai/rmind `feat/throttle-rebalance-otf`): first 2-GPU smoke showed both ranks iterating the identical unsharded 549-batch epoch. An audit of the W&B project found no prior `devices>1` runs on this loader, so no historical results are affected — the trap was latent.

## Fix

- **Lazy build**: sampler + node graph construction is deferred to first `iter()`/`len()` — framework integrations (hydra + Lightning) instantiate the loader before `trainer.fit` initializes the process group, so an init-time `is_initialized()` check can never shard rank 0. A rebuild guard re-shards if the process group appears after a premature build.
- **`DistributedSampler`** (disjoint shards; `world_size × per-rank batch = effective batch`) whenever `torch.distributed` is initialized; bit-identical previous behavior otherwise.
- **`set_epoch()`** exposed for per-epoch reshuffling (Lightning only forwards epochs to plain DataLoaders; rmind ships a small callback calling this).
- **`method='process'` rejected under distributed training**: ParallelMapper workers fork after CUDA init and deadlock (known failure, previously observed single-GPU with the shared-memory TensorDict).

## Verification

- [2-GPU DDP training in rmind](https://wandb.ai/yaak/rmind/runs/ylpsmyv9?nw=nwusermax_yaak) on 2× RTX 4090: both ranks log `distributed sampler rank={0,1} world_size=2 shard_len=N/2` and train normally.
- New gloo-backend unit tests: fallback without process group, sharding + `set_epoch` with one, late-group rebuild guard, process-method rejection. (`test_dataloaders[{thread,process}-yaak_dataset]` fail identically on clean `main` in my environment — pre-existing, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)