### PR TITLE
feat: nero-arms ingestion (MCAP gloves + 3 cameras -> 30 Hz rbyte dataset)

### DIFF
--- a/config/_templates/dataset/nero_arms.yaml
+++ b/config/_templates/dataset/nero_arms.yaml
@@ -196,7 +196,9 @@ samples:
         func:
           _target_: rbyte.io.NeroArmsDataFrameBuilder
           action_horizon: #@ action_horizon
-          #! §6.1 auxiliary blocks, off by default.
+          #! §6.1 auxiliary blocks, off by default. NOTE: turning either on
+          #! ALSO requires uncommenting the matching line in the cast step
+          #! below, otherwise the column is built and then silently dropped.
           include_imu: false
           include_status_flags: false
           cameras:
@@ -271,6 +273,10 @@ samples:
                      "state.pose_rel_start"::FLOAT[46][2][(@=str(clip_length)@)] AS "state.pose_rel_start",
                      "action.future_state"::FLOAT[46][2][(@=str(action_horizon)@)][(@=str(clip_length)@)] AS "action.future_state",
                      "action.future_state"::FLOAT[46][2][(@=str(action_horizon)@)][(@=str(clip_length)@)] AS "action.commanded",
+                     -- uncomment together with `include_imu` above:
+                     -- "state.imu"::FLOAT[42][2][(@=str(clip_length)@)] AS "state.imu",
+                     -- uncomment together with `include_status_flags` above:
+                     -- "state.status_flags"::INT32[8][2][(@=str(clip_length)@)] AS "state.status_flags",
                      "align_residual_ms"::FLOAT[(@=str(clip_length)@)] AS "align_residual_ms",
                      "side_valid"[1]::BOOLEAN[2] AS "side_valid",
                      "camera_cond"[1]::FLOAT[13][3] AS "camera_cond",

--- a/config/_templates/dataset/nero_arms.yaml
+++ b/config/_templates/dataset/nero_arms.yaml
@@ -1,0 +1,292 @@
+#@yaml/text-templated-strings
+
+#@ # nero-arms (data contract v0.1). One episode == one directory under `${data_dir}`.
+#@ # `${data_dir}` is the recording-session root:
+#@ #   linux: /nasa/drives/nero-arms/gloves-mcap-recordings/2026-07-17
+#@ #   macos: /Volumes/data/drives/nero-arms/gloves-mcap-recordings/2026-07-17
+#@ # Regenerate the manifest below with:
+#@ #   ls -d $data_dir/*/ | xargs -n1 basename
+#@ episodes = [
+#@     "2026-07-17--14-22-20-607711",
+#@     "2026-07-17--14-22-31-803566",
+#@     "2026-07-17--14-22-40-179540",
+#@     "2026-07-17--14-22-48-219503",
+#@     "2026-07-17--14-22-57-255544",
+#@     "2026-07-17--14-23-06-591575",
+#@     "2026-07-17--14-23-14-127548",
+#@     "2026-07-17--14-23-20-763578",
+#@     "2026-07-17--14-23-32-655468",
+#@     "2026-07-17--14-23-42-783430",
+#@     "2026-07-17--14-23-49-815377",
+#@     "2026-07-17--14-23-59-823487",
+#@     "2026-07-17--14-24-09-495466",
+#@     "2026-07-17--14-24-23-787441",
+#@     "2026-07-17--14-24-33-543423",
+#@     "2026-07-17--14-24-40-875434",
+#@     "2026-07-17--14-24-50-343519",
+#@     "2026-07-17--14-25-00-543444",
+#@     "2026-07-17--14-25-09-435451",
+#@     "2026-07-17--14-25-19-551448",
+#@     "2026-07-17--14-25-28-119475",
+#@     "2026-07-17--14-25-45-627503",
+#@     "2026-07-17--14-25-53-307254",
+#@     "2026-07-17--14-26-03-927340",
+#@     "2026-07-17--14-26-16-215327",
+#@     "2026-07-17--14-26-26-607210",
+#@     "2026-07-17--14-26-35-331240",
+#@     "2026-07-17--14-26-56-199194",
+#@     "2026-07-17--14-27-05-007302",
+#@     "2026-07-17--14-27-14-199178",
+#@     "2026-07-17--14-27-23-799180",
+#@     "2026-07-17--14-27-33-207118",
+#@     "2026-07-17--14-27-44-055195",
+#@     "2026-07-17--14-27-53-283163",
+#@     "2026-07-17--14-35-37-610686",
+#@     "2026-07-17--14-35-45-914670",
+#@     "2026-07-17--14-35-53-294755",
+#@     "2026-07-17--14-36-04-070797",
+#@     "2026-07-17--14-36-14-798576",
+#@     "2026-07-17--14-36-26-546594",
+#@     "2026-07-17--14-36-35-390647",
+#@     "2026-07-17--14-36-43-094554",
+#@     "2026-07-17--14-36-50-798587",
+#@     "2026-07-17--14-36-58-298836",
+#@     "2026-07-17--14-37-06-038565",
+#@     "2026-07-17--14-37-15-950578",
+#@     "2026-07-17--14-37-23-390613",
+#@     "2026-07-17--14-37-30-998719",
+#@     "2026-07-17--14-37-39-410526",
+#@     "2026-07-17--14-37-47-570566",
+#@     "2026-07-17--14-37-56-042516",
+#@     "2026-07-17--14-38-04-754534",
+#@     "2026-07-17--14-38-12-854496",
+#@     "2026-07-17--14-38-20-702491",
+#@     "2026-07-17--14-38-30-578487",
+#@     "2026-07-17--14-38-38-930449",
+#@     "2026-07-17--14-38-46-778423",
+#@     "2026-07-17--14-38-55-718502",
+#@     "2026-07-17--14-39-08-570475",
+#@     "2026-07-17--14-39-18-602516",
+#@     "2026-07-17--14-39-28-586461",
+#@     "2026-07-17--14-39-36-710457",
+#@     "2026-07-17--14-39-45-482445",
+#@     "2026-07-17--14-39-53-702431",
+#@     "2026-07-17--14-40-02-054411",
+#@     "2026-07-17--14-40-11-042411",
+#@     "2026-07-17--14-40-18-782425",
+#@     "2026-07-17--14-40-27-362408",
+#@     "2026-07-17--14-40-34-250387",
+#@     "2026-07-17--14-40-42-854341",
+#@     "2026-07-17--14-40-50-858305",
+#@     "2026-07-17--14-41-00-602300",
+#@     "2026-07-17--14-41-12-170262",
+#@     "2026-07-17--14-41-20-558390",
+#@     "2026-07-17--14-41-31-046297",
+#@     "2026-07-17--14-41-41-582286",
+#@     "2026-07-17--14-41-52-634246",
+#@     "2026-07-17--14-41-59-918281",
+#@     "2026-07-17--14-42-18-710264",
+#@     "2026-07-17--14-42-26-246252",
+#@     "2026-07-17--14-42-34-490301",
+#@     "2026-07-17--14-42-41-606262",
+#@     "2026-07-17--14-42-49-970236",
+#@     "2026-07-17--14-42-57-326197",
+#@     "2026-07-17--14-43-07-094241",
+#@     "2026-07-17--14-43-14-078161",
+#@     "2026-07-17--14-43-21-590277",
+#@     "2026-07-17--14-43-28-730235",
+#@     "2026-07-17--14-43-37-946180",
+#@     "2026-07-17--14-43-46-562202",
+#@     "2026-07-17--14-43-57-782226",
+#@     "2026-07-17--14-44-02-726195",
+#@     "2026-07-17--14-44-10-202176",
+#@     "2026-07-17--14-44-17-582252",
+#@     "2026-07-17--14-44-24-530284",
+#@     "2026-07-17--14-44-32-354217",
+#@     "2026-07-17--14-44-42-770054",
+#@     "2026-07-17--14-44-51-122076",
+#@     "2026-07-17--14-44-58-310208",
+#@     "2026-07-17--14-45-05-978085",
+#@     "2026-07-17--14-45-14-450062",
+#@     "2026-07-17--14-45-25-118042",
+#@     "2026-07-17--14-45-33-074099",
+#@     "2026-07-17--14-45-41-126070",
+#@ ]
+
+#@ # §7.2: the cameras are heterogeneous (base 1920x1080, sides 1280x800). The
+#@ # decode-time resize below is **isotropic** for every camera (base x0.25,
+#@ # sides x0.375), which leaves the resolution-normalised intrinsics in
+#@ # `camera_cond` (§7.1) exactly valid. Any anisotropic resize/crop/letterbox
+#@ # must be mirrored into `calibration.yaml` or `camera_cond` will describe a
+#@ # camera that does not match the pixels.
+#@ cameras = {
+#@     "base": [270, 480],
+#@     "side_left": [300, 480],
+#@     "side_right": [300, 480],
+#@ }
+
+#@ # §8: T = clip length. rmind PR #265 uses episode_length=6.
+#@ clip_length = 6
+#@ # §6.2: action == the chunk of future states [t+1 .. t+H].
+#@ action_horizon = 6
+---
+_target_: rbyte.Dataset.from_config
+_recursive_: false
+_convert_: all
+streams:
+  #@ for/end camera, size in cameras.items():
+  image.(@=camera@):
+    index: frame_index.(@=camera@)
+    sources:
+      #@ for/end episode in episodes:
+      (@=episode@):
+        _target_: rbyte.io.TorchCodecFrameSource
+        source: ${data_dir}/(@=episode@)/(@=camera@).mp4
+        transforms:
+          - _target_: torchcodec.transforms.Resize
+            size: #@ size
+
+  #@ for/end camera, size in cameras.items():
+  goal.image.(@=camera@):
+    index: goal.frame_index.(@=camera@)
+    sources:
+      #@ for/end episode in episodes:
+      (@=episode@):
+        _target_: rbyte.io.TorchCodecFrameSource
+        source: ${data_dir}/(@=episode@)/(@=camera@).mp4
+        transforms:
+          - _target_: torchcodec.transforms.Resize
+            size: #@ size
+
+samples:
+  inputs:
+    input_id:
+      #@ for/end episode in episodes:
+      - (@=episode@)
+
+    mcap_path:
+      #@ for/end episode in episodes:
+      - ${data_dir}/(@=episode@)/data.mcap
+
+    calibration_path:
+      #@ for/end episode in episodes:
+      - ${data_dir}/calibration.yaml
+
+    #@ for/end camera in cameras:
+    (@=camera@)_path:
+      #@ for/end episode in episodes:
+      - ${data_dir}/(@=episode@)/(@=camera@).mp4
+
+  executor:
+    _target_: concurrent.futures.ProcessPoolExecutor
+    max_workers: 1
+    mp_context:
+      _target_: multiprocessing.get_context
+      method: forkserver
+
+  pipeline:
+    _target_: pipefunc.Pipeline
+    validate_type_annotations: false
+    functions:
+      - _target_: pipefunc.PipeFunc
+        renames:
+          path: mcap_path
+        output_name: nero
+        mapspec: "${.renames.path}[i], calibration_path[i] -> ${.output_name}[i]"
+        func:
+          _target_: rbyte.io.NeroArmsDataFrameBuilder
+          action_horizon: #@ action_horizon
+          #! §6.1 auxiliary blocks, off by default.
+          include_imu: false
+          include_status_flags: false
+          cameras:
+            #@ for/end camera in cameras:
+            - (@=camera@)
+          reference_camera: (@=list(cameras)[0]@)
+
+      #@ for/end camera in cameras:
+      - _target_: pipefunc.PipeFunc
+        renames:
+          path: (@=camera@)_path
+        output_name: (@=camera@)_meta
+        mapspec: "${.renames.path}[i] -> ${.output_name}[i]"
+        func:
+          _target_: rbyte.io.VideoDataFrameBuilder
+          fields:
+            frame_idx:
+              _target_: polars.Int32
+
+      #@ # §3: each camera is joined on its own `frame_index`; the semi-joins drop
+      #@ # any row whose frame is missing from the corresponding mp4.
+      - _target_: pipefunc.PipeFunc
+        output_name: filtered
+        mapspec: "nero[i], base_meta[i], side_left_meta[i], side_right_meta[i] -> ${.output_name}[i]"
+        func:
+          _target_: makefun.create_function
+          func_signature: "filter(*, nero, base_meta, side_left_meta, side_right_meta)"
+          func_impl:
+            _target_: rbyte.io.DuckDBDataFrameQuery
+            query: |
+              SELECT *
+              FROM
+                nero
+                SEMI JOIN base_meta
+                  ON nero."frame_index.base" = base_meta.frame_idx
+                SEMI JOIN side_left_meta
+                  ON nero."frame_index.side_left" = side_left_meta.frame_idx
+                SEMI JOIN side_right_meta
+                  ON nero."frame_index.side_right" = side_right_meta.frame_idx
+              WHERE
+                COLUMNS(*) IS NOT NULL
+              ORDER BY
+                nero."frame_index.base"
+
+      - _target_: pipefunc.PipeFunc
+        renames:
+          input: filtered
+        output_name: samples
+        mapspec: "${.renames.input}[i] -> ${.output_name}[i]"
+        func:
+          _target_: rbyte.io.DataFrameGroupByDynamic
+          index_column: frame_index.base
+          #! dense, overlapping windows
+          every: 1i
+          period: (@=str(clip_length)@)i
+
+      #@ # fixed-shape casts (rbyte requires `polars.Array`, not `List`) and the
+      #@ # per-episode constants collapsed back to a single value per sample.
+      - _target_: pipefunc.PipeFunc
+        output_name: samples_cast
+        mapspec: "samples[i] -> ${.output_name}[i]"
+        func:
+          _target_: makefun.create_function
+          func_signature: "cast(*, samples)"
+          func_impl:
+            _target_: rbyte.io.DuckDBDataFrameQuery
+            query: |
+              SELECT "frame_index.base"::INT32[(@=str(clip_length)@)] AS "frame_index.base",
+                     "frame_index.side_left"::INT32[(@=str(clip_length)@)] AS "frame_index.side_left",
+                     "frame_index.side_right"::INT32[(@=str(clip_length)@)] AS "frame_index.side_right",
+                     "state.pose"::FLOAT[46][2][(@=str(clip_length)@)] AS "state.pose",
+                     "state.pose_rel_start"::FLOAT[46][2][(@=str(clip_length)@)] AS "state.pose_rel_start",
+                     "action.future_state"::FLOAT[46][2][(@=str(action_horizon)@)][(@=str(clip_length)@)] AS "action.future_state",
+                     "action.future_state"::FLOAT[46][2][(@=str(action_horizon)@)][(@=str(clip_length)@)] AS "action.commanded",
+                     "align_residual_ms"::FLOAT[(@=str(clip_length)@)] AS "align_residual_ms",
+                     "side_valid"[1]::BOOLEAN[2] AS "side_valid",
+                     "camera_cond"[1]::FLOAT[13][3] AS "camera_cond",
+                     "camera_cond.placeholder"[1]::BOOLEAN AS "camera_cond.placeholder",
+                     "goal.xyz"[1]::FLOAT[3][2] AS "goal.xyz",
+                     "goal.frame_index.base"[1]::INT32 AS "goal.frame_index.base",
+                     "goal.frame_index.side_left"[1]::INT32 AS "goal.frame_index.side_left",
+                     "goal.frame_index.side_right"[1]::INT32 AS "goal.frame_index.side_right"
+              FROM samples
+              WHERE len("frame_index.base") == (@=str(clip_length)@)
+
+      - _target_: pipefunc.PipeFunc
+        renames:
+          keys: input_id
+          values: samples_cast
+        output_name: samples_aggregated
+        func:
+          _target_: rbyte.io.DataFrameConcater
+          key_column: input_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ geo = ["polars-st==0.4.3"]
 hdf5 = ["h5py>=3.14.0"]
 jpeg = ["simplejpeg>=1.9.0"]
 mcap = ["mcap>=1.3.1", "mcap-protobuf-support>=0.5.4", "protobuf"]
+nero = ["mcap>=1.3.1", "mcap-protobuf-support>=0.5.4", "protobuf", "pyyaml>=6.0.2"]
 protos = ["grpcio-tools==1.71.0", "protoletariat>=3.3.10"]
 video = ["torchcodec>=0.13.0"]
 visualize = [
@@ -128,6 +129,7 @@ ignore = [
   "A001",
   "A002",
   "D",
+  "DOC",
   "CPY",
   "COM812",
   "F722",

--- a/src/rbyte/io/__init__.py
+++ b/src/rbyte/io/__init__.py
@@ -47,6 +47,13 @@ else:
     ]
 
 try:  # noqa: RUF067
+    from .nero import NeroArmsCalibration, NeroArmsDataFrameBuilder
+except ImportError:
+    pass
+else:
+    __all__ += ["NeroArmsCalibration", "NeroArmsDataFrameBuilder"]
+
+try:  # noqa: RUF067
     from .video import TorchCodecFrameSource, VideoDataFrameBuilder
 except (ImportError, RuntimeError):
     pass

--- a/src/rbyte/io/nero/__init__.py
+++ b/src/rbyte/io/nero/__init__.py
@@ -1,0 +1,45 @@
+from .calibration import CAMERA_COND_DIM, CameraModel, NeroArmsCalibration
+from .dataframe_builder import NeroArmsDataFrameBuilder
+from .rotation import (
+    canonicalize_quat,
+    pose_9d_to_quat,
+    pose_quat_to_9d,
+    quat_slerp,
+    quat_to_rot6d,
+    rot6d_to_quat,
+)
+from .schema import (
+    CAMERAS,
+    FINGERS,
+    IMU_DIM,
+    IMU_SEGMENTS,
+    SIDES,
+    STATE_DIM_9D,
+    STATE_DIM_QUAT,
+    STATUS_SENSORS,
+    state_9d_to_quat,
+    state_quat_to_9d,
+)
+
+__all__ = [
+    "CAMERAS",
+    "CAMERA_COND_DIM",
+    "FINGERS",
+    "IMU_DIM",
+    "IMU_SEGMENTS",
+    "SIDES",
+    "STATE_DIM_9D",
+    "STATE_DIM_QUAT",
+    "STATUS_SENSORS",
+    "CameraModel",
+    "NeroArmsCalibration",
+    "NeroArmsDataFrameBuilder",
+    "canonicalize_quat",
+    "pose_9d_to_quat",
+    "pose_quat_to_9d",
+    "quat_slerp",
+    "quat_to_rot6d",
+    "rot6d_to_quat",
+    "state_9d_to_quat",
+    "state_quat_to_9d",
+]

--- a/src/rbyte/io/nero/calibration.py
+++ b/src/rbyte/io/nero/calibration.py
@@ -1,0 +1,114 @@
+"""Camera calibration sidecar for nero-arms (data contract §7).
+
+Calibration is not present in the MCAP. It is read from a YAML sidecar keyed by
+camera name, resolved per recording-session directory, so that real calibration
+is a file drop. Until then the file carries `placeholder: true` and every
+consumer is expected to assert on it -- `NeroArmsCalibration.placeholder` is
+also emitted as a per-sample column so the assertion can be made on a batch.
+"""
+
+from collections.abc import Sequence
+from enum import StrEnum, auto, unique
+from pathlib import Path
+from typing import Annotated, Self, final
+
+import numpy as np
+import numpy.typing as npt
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, FilePath, validate_call
+from structlog import get_logger
+
+from rbyte.io.nero.rotation import matrix_to_quat, quat_to_rot6d
+
+__all__ = ["CAMERA_COND_DIM", "CameraModel", "NeroArmsCalibration"]
+
+logger = get_logger(__name__)
+
+#: §7.1: `fx/W, fy/H, cx/W, cy/H` + `t_world_cam` (3) + `R_world_cam` as 6D.
+CAMERA_COND_DIM = 13
+
+
+@unique
+class CameraModel(StrEnum):
+    pinhole = auto()
+    opencv = auto()
+    opencv_fisheye = auto()
+
+
+class Intrinsics(BaseModel):
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class CameraCalibration(BaseModel):
+    model: CameraModel
+    image_size: tuple[int, int]
+    intrinsics: Intrinsics
+    distortion: Sequence[float] = ()
+    T_world_cam: Annotated[Sequence[Sequence[float]], Field(min_length=4, max_length=4)]
+
+    model_config = ConfigDict(extra="forbid", protected_namespaces=())
+
+    @property
+    def cond(self) -> npt.NDArray[np.float32]:
+        """§7.1 conditioning vector, `(13,)` float32.
+
+        The intrinsics are resolution-normalised, which makes the vector
+        invariant to an *isotropic* resize of the image. Any anisotropic resize,
+        crop or letterbox applied to the pixels must be propagated into
+        `intrinsics`/`image_size` here as well (§7.2), otherwise the
+        conditioning vector describes a camera that does not match the pixels.
+        """
+        w, h = self.image_size
+        t_world_cam = np.asarray(self.T_world_cam, dtype=np.float64)
+        r_world_cam = t_world_cam[:3, :3]
+
+        return np.concatenate([
+            [
+                self.intrinsics.fx / w,
+                self.intrinsics.fy / h,
+                self.intrinsics.cx / w,
+                self.intrinsics.cy / h,
+            ],
+            t_world_cam[:3, 3],
+            quat_to_rot6d(matrix_to_quat(r_world_cam)),
+        ]).astype(np.float32)
+
+
+@final
+class NeroArmsCalibration(BaseModel):
+    version: int
+    world_frame: str
+    cameras: dict[str, CameraCalibration]
+    placeholder: bool = True
+
+    model_config = ConfigDict(extra="forbid")
+
+    @classmethod
+    @validate_call
+    def from_path(cls, path: FilePath) -> Self:
+        with Path(path).open(encoding="utf-8") as f:
+            calibration = cls.model_validate(yaml.safe_load(f))
+
+        if calibration.placeholder:
+            logger.warning(
+                "using PLACEHOLDER camera calibration -- extrinsics are identity "
+                "and intrinsics are zero; `placeholder` must be false before any "
+                "real training run",
+                path=Path(path).as_posix(),
+            )
+
+        return calibration
+
+    def cond(self, cameras: Sequence[str]) -> npt.NDArray[np.float32]:
+        """§7.1 conditioning matrix, `(len(cameras), 13)` float32."""
+        if missing := set(cameras) - self.cameras.keys():
+            logger.error(msg := "calibration missing cameras", cameras=sorted(missing))
+
+            raise ValueError(msg)
+
+        return np.stack([self.cameras[camera].cond for camera in cameras])

--- a/src/rbyte/io/nero/calibration.py
+++ b/src/rbyte/io/nero/calibration.py
@@ -51,6 +51,16 @@ class CameraCalibration(BaseModel):
     distortion: Sequence[float] = ()
     T_world_cam: Annotated[Sequence[Sequence[float]], Field(min_length=4, max_length=4)]
 
+    # Provenance, written by read_oak_intrinsics.py when the values come from
+    # device EEPROM. Optional so hand-written and placeholder files still load.
+    mxid: str | None = None
+    socket: str | None = None
+    rotated_180: bool = False
+    """The recorder rotates every camera 180 degrees, and the EEPROM intrinsics
+    describe the unrotated sensor, so `intrinsics`/`distortion` here must already
+    carry that correction. This flag records that it was applied -- it is a
+    marker, not an instruction: nothing downstream re-applies it."""
+
     model_config = ConfigDict(extra="forbid", protected_namespaces=())
 
     @property
@@ -85,6 +95,10 @@ class NeroArmsCalibration(BaseModel):
     world_frame: str
     cameras: dict[str, CameraCalibration]
     placeholder: bool = True
+
+    intrinsics_source: str | None = None
+    """Where the intrinsics came from -- "eeprom" when read off the devices by
+    read_oak_intrinsics.py, None for hand-written or placeholder files."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/src/rbyte/io/nero/dataframe_builder.py
+++ b/src/rbyte/io/nero/dataframe_builder.py
@@ -1,0 +1,652 @@
+"""nero-arms MCAP -> 30 Hz camera-grid dataframe (data contract §3, §5, §6, §9)."""
+
+from collections import defaultdict
+from collections.abc import Sequence
+from os import PathLike
+from pathlib import Path
+from typing import Final, NamedTuple, final
+
+import numpy as np
+import numpy.typing as npt
+import polars as pl
+from mcap.reader import make_reader
+from mcap_protobuf.decoder import DecoderFactory
+from pydantic import NonNegativeFloat, PositiveInt, validate_call
+from structlog import get_logger
+from structlog.contextvars import bound_contextvars
+
+from rbyte.io.nero.calibration import NeroArmsCalibration
+from rbyte.io.nero.rotation import canonicalize_quat, quat_slerp, quat_to_matrix
+from rbyte.io.nero.schema import (
+    CAMERAS,
+    FINGERS,
+    IMU_DIM,
+    IMU_SEGMENTS,
+    SIDES,
+    STATE_DIM_QUAT,
+    STATUS_SENSORS,
+)
+
+logger = get_logger(__name__)
+
+__all__ = ["NeroArmsDataFrameBuilder"]
+
+_TIMING_TOPIC: Final = "timing.rgmp"
+_IMAGE_TOPIC_PREFIX: Final = "observation.images."
+_HUB_ORIENTATION_TOPIC: Final = "hub.LTP_NED.orientation"
+_NS_PER_MS: Final = 1e6
+#: §3.4: one glove period at 83.4 Hz.
+_GLOVE_PERIOD_MS: Final = 12.0
+_POSE_WIDTH: Final = 7
+_QUAT_WIDTH: Final = 4
+
+type _Floats = dict[str, list[list[float]]]
+type _Ints = dict[str, list[list[int]]]
+
+
+class _Stream(NamedTuple):
+    """A device-clock time base plus the host-clock arrival stamps for it.
+
+    Device epochs are unrelated across devices (§3.2), so every stream is mapped
+    onto a common (host) clock via a single constant offset estimated from
+    `host_arrival_time_ns - device_timestamp_ns`.
+    """
+
+    device_ns: npt.NDArray[np.int64]
+    host_ns: npt.NDArray[np.int64]
+    #: percentile of the observed latency used as the offset estimate; 0 is the
+    #: pure minimum-latency estimator. The mean is biased by transport jitter.
+    percentile: float = 0.0
+
+    @property
+    def latency_ns(self) -> npt.NDArray[np.int64]:
+        return self.host_ns - self.device_ns
+
+    @property
+    def offset_ns(self) -> int:
+        return int(np.percentile(self.latency_ns, self.percentile, method="lower"))
+
+    @property
+    def common_ns(self) -> npt.NDArray[np.int64]:
+        return self.device_ns + self.offset_ns
+
+    @property
+    def latency_spread_ms(self) -> float:
+        latency = self.latency_ns
+
+        return float(np.max(latency) - np.min(latency)) / _NS_PER_MS
+
+    @property
+    def offset_drift_ms(self) -> float:
+        """Offset estimated on the first vs the second half of the episode.
+
+        §3.2 asserts a per-episode constant offset is sufficient (drift < 7 ms);
+        this is the number that claim should be checked against.
+        """
+        half = len(self.device_ns) // 2
+        if half == 0:
+            return 0.0
+
+        first = _Stream(self.device_ns[:half], self.host_ns[:half], self.percentile)
+        second = _Stream(self.device_ns[half:], self.host_ns[half:], self.percentile)
+
+        return abs(first.offset_ns - second.offset_ns) / _NS_PER_MS
+
+
+class _Camera(NamedTuple):
+    frame_index: npt.NDArray[np.int32]
+    stream: _Stream
+
+
+class _Resampling(NamedTuple):
+    """The §3.3 resampling plan: reference grid + bracketing glove samples."""
+
+    #: reference-camera timestamps on the common clock, extrapolation excluded
+    grid_ns: npt.NDArray[np.int64]
+    #: the reference camera's own `frame_index` for those timestamps
+    frame_index: npt.NDArray[np.int32]
+    lo: npt.NDArray[np.intp]
+    hi: npt.NDArray[np.intp]
+    #: interpolation parameter within `[lo, hi]`
+    u: npt.NDArray[np.float64]
+    #: whichever of `lo`/`hi` is closer in time -- for non-interpolable values
+    nearest: npt.NDArray[np.intp]
+    #: §3.4: distance to the nearest bracketing glove sample
+    residual_ms: npt.NDArray[np.float64]
+
+    def lerp(self, values: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        u = self.u[:, None]
+
+        return values[self.lo] * (1.0 - u) + values[self.hi] * u
+
+    def slerp(self, values: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        return canonicalize_quat(
+            quat_slerp(
+                canonicalize_quat(values[self.lo]),
+                canonicalize_quat(values[self.hi]),
+                self.u,
+            )
+        )
+
+
+def _topic(side: str, name: str) -> str:
+    return f"{side}.{name}"
+
+
+@final
+class NeroArmsDataFrameBuilder:
+    """Build the per-episode 30 Hz dataframe for one nero-arms recording.
+
+    Reads a `data.mcap`, aligns the glove stream onto the reference camera's
+    device-clock grid (§3), canonicalises quaternions (§5.1), assembles the
+    bimanual state/action blocks with a `side_valid` mask (§6) and the goal
+    blocks (§9).
+
+    Emitted columns (one row per reference-camera frame):
+
+    | column                        | dtype                        |
+    |-------------------------------|------------------------------|
+    | `frame_index.{camera}`        | `Int32`                      |
+    | `state.pose`                  | `Array(Float32, (2, 46))`    |
+    | `state.pose_rel_start`        | `Array(Float32, (2, 46))`    |
+    | `action.future_state`         | `Array(Float32, (H, 2, 46))` |
+    | `side_valid`                  | `Array(Boolean, 2)`          |
+    | `align_residual_ms`           | `Float32`                    |
+    | `camera_cond`                 | `Array(Float32, (3, 13))`    |
+    | `camera_cond.placeholder`     | `Boolean`                    |
+    | `goal.xyz`                    | `Array(Float32, (2, 3))`     |
+    | `goal.frame_index.{camera}`   | `Int32`                      |
+    | `state.imu`                   | `Array(Float32, (2, 42))`    |
+    | `state.status_flags`          | `Array(Int32, (2, 8))`       |
+
+    `state.pose` is the **storage** form of §5.2 (7 floats per pose, 46 per
+    side). Use `rbyte.io.nero.state_quat_to_9d` to obtain the 60-dim
+    model-facing form of §6.1 at the rmind input boundary.
+
+    The last `action_horizon` rows of every episode are dropped: they have no
+    full future chunk, and clamping or wrapping the chunk would fabricate data.
+    """
+
+    __name__ = __qualname__
+
+    @validate_call
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        cameras: Sequence[str] = CAMERAS,
+        reference_camera: str = CAMERAS[0],
+        sides: Sequence[str] = SIDES,
+        action_horizon: PositiveInt = 6,
+        align_tolerance_ms: NonNegativeFloat = _GLOVE_PERIOD_MS,
+        camera_gap_tolerance_ms: NonNegativeFloat = 50.0,
+        offset_percentile: NonNegativeFloat = 0.0,
+        include_imu: bool = False,
+        include_status_flags: bool = False,
+    ) -> None:
+        if reference_camera not in cameras:
+            logger.error(msg := "`reference_camera` not in `cameras`")
+
+            raise ValueError(msg)
+
+        self._cameras = tuple(cameras)
+        self._reference_camera = reference_camera
+        self._sides = tuple(sides)
+        self._action_horizon = action_horizon
+        self._align_tolerance_ms = align_tolerance_ms
+        self._camera_gap_tolerance_ms = camera_gap_tolerance_ms
+        self._offset_percentile = offset_percentile
+        self._include_imu = include_imu
+        self._include_status_flags = include_status_flags
+
+    def __call__(
+        self, path: PathLike[str] | str, calibration_path: PathLike[str] | str
+    ) -> pl.DataFrame:
+        with bound_contextvars(path=str(path)):
+            result = self._build(Path(path), Path(calibration_path))
+            logger.debug("built dataframe", length=len(result))
+
+            return result
+
+    # ------------------------------------------------------------------ topics
+
+    @property
+    def _pose_topics(self) -> tuple[str, ...]:
+        return (
+            "arm_sensor.coil_pro.transform",
+            *(f"{finger}_finger_sensor.hub.transform" for finger in FINGERS),
+        )
+
+    def _side_topics(self, side: str) -> tuple[str, ...]:
+        return (
+            *(_topic(side, topic) for topic in self._pose_topics),
+            _topic(side, _HUB_ORIENTATION_TOPIC),
+        )
+
+    @property
+    def _topics(self) -> tuple[str, ...]:
+        topics = [
+            _TIMING_TOPIC,
+            *(f"{_IMAGE_TOPIC_PREFIX}{camera}" for camera in self._cameras),
+        ]
+        for side in self._sides:
+            topics += self._side_topics(side)
+            if self._include_imu:
+                topics += [
+                    _topic(side, f"{segment}_imu.{field}")
+                    for segment in IMU_SEGMENTS
+                    for field in ("angular_velocity", "proper_acceleration")
+                ]
+            if self._include_status_flags:
+                topics += [
+                    _topic(side, f"{sensor}.status_flags") for sensor in STATUS_SENSORS
+                ]
+
+        return tuple(topics)
+
+    # -------------------------------------------------------------------- read
+
+    def _read(self, path: Path) -> tuple[_Floats, _Ints]:
+        floats: _Floats = defaultdict(list)
+        ints: _Ints = defaultdict(list)
+
+        with path.open("rb") as f:
+            reader = make_reader(f, decoder_factories=[DecoderFactory()])
+            for _schema, channel, _message, decoded in reader.iter_decoded_messages(
+                topics=self._topics
+            ):
+                topic = channel.topic
+                match topic.rsplit(".", 1)[-1]:
+                    case "transform":
+                        floats[topic].append([
+                            decoded.x,
+                            decoded.y,
+                            decoded.z,
+                            decoded.qx,
+                            decoded.qy,
+                            decoded.qz,
+                            decoded.qw,
+                        ])
+
+                    case "orientation":
+                        floats[topic].append([
+                            decoded.qx,
+                            decoded.qy,
+                            decoded.qz,
+                            decoded.qw,
+                        ])
+
+                    case "angular_velocity" | "proper_acceleration":
+                        floats[topic].append([decoded.x, decoded.y, decoded.z])
+
+                    case "status_flags":
+                        ints[topic].append([decoded.bit_mapped_flags])
+
+                    case "rgmp":
+                        ints[topic].append([
+                            decoded.device_timestamp_us * 1_000,
+                            decoded.host_arrival_time_ns,
+                        ])
+
+                    case _:  # observation.images.{camera}
+                        ints[topic].append([
+                            decoded.frame_index,
+                            decoded.device_timestamp_ns,
+                            decoded.host_arrival_time_ns,
+                        ])
+
+        return floats, ints
+
+    # ---------------------------------------------------------------- timebase
+
+    def _glove(self, floats: _Floats, ints: _Ints) -> _Stream:
+        if _TIMING_TOPIC not in ints:
+            logger.error(msg := "missing timing topic", topic=_TIMING_TOPIC)
+
+            raise ValueError(msg)
+
+        timing = np.asarray(ints[_TIMING_TOPIC], dtype=np.int64)
+        glove = _Stream(timing[:, 0], timing[:, 1], self._offset_percentile)
+
+        # §3.1: the glove sensor topics carry no timestamps of their own; they
+        # are published one-per-`timing.rgmp` sample, so the join is ordinal --
+        # a single length mismatch would silently shift every pose.
+        for topic, values in (*floats.items(), *ints.items()):
+            if topic.startswith(_IMAGE_TOPIC_PREFIX) or topic == _TIMING_TOPIC:
+                continue
+
+            if len(values) != len(glove.device_ns):
+                logger.error(
+                    msg := "glove topic length != `timing.rgmp` length",
+                    topic=topic,
+                    length=len(values),
+                    expected=len(glove.device_ns),
+                )
+
+                raise ValueError(msg)
+
+        return glove
+
+    def _cameras_from(self, ints: _Ints) -> dict[str, _Camera]:
+        cameras: dict[str, _Camera] = {}
+        for camera in self._cameras:
+            topic = f"{_IMAGE_TOPIC_PREFIX}{camera}"
+            if topic not in ints:
+                logger.error(msg := "missing camera topic", topic=topic)
+
+                raise ValueError(msg)
+
+            values = np.asarray(ints[topic], dtype=np.int64)
+            cameras[camera] = _Camera(
+                values[:, 0].astype(np.int32),
+                _Stream(values[:, 1], values[:, 2], self._offset_percentile),
+            )
+
+        return cameras
+
+    def _resample(self, glove: _Stream, reference: _Camera) -> _Resampling:
+        glove_ns = glove.common_ns
+        grid_ns = reference.stream.common_ns
+
+        # §3.3: never extrapolate. Reference frames outside the glove stream's
+        # span are dropped rather than clamped.
+        inside = (grid_ns >= glove_ns[0]) & (grid_ns <= glove_ns[-1])
+        if (dropped := int((~inside).sum())) > 0:
+            logger.debug(
+                "dropped reference frames outside the glove stream span",
+                count=dropped,
+                total=len(grid_ns),
+            )
+
+        grid_ns = grid_ns[inside]
+        if grid_ns.size == 0:
+            logger.error(msg := "no reference frames overlap the glove stream")
+
+            raise ValueError(msg)
+
+        hi = np.searchsorted(glove_ns, grid_ns, side="left").clip(1, len(glove_ns) - 1)
+        lo = hi - 1
+        t_lo, t_hi = glove_ns[lo], glove_ns[hi]
+        to_lo, to_hi = grid_ns - t_lo, t_hi - grid_ns
+
+        # §3.4: the actual interpolation distance -- not the clock-offset drift,
+        # which is near-constant and would make the tolerance check vacuous.
+        residual_ms = np.minimum(to_lo, to_hi).astype(np.float64) / _NS_PER_MS
+        if (worst := float(residual_ms.max())) > self._align_tolerance_ms:
+            logger.error(
+                msg := "alignment residual exceeds one glove period",
+                residual_ms=round(worst, 3),
+                tolerance_ms=self._align_tolerance_ms,
+            )
+
+            raise ValueError(msg)
+
+        return _Resampling(
+            grid_ns=grid_ns,
+            frame_index=reference.frame_index[inside],
+            lo=lo,
+            hi=hi,
+            u=(to_lo / np.maximum(t_hi - t_lo, 1)),
+            nearest=np.where(to_lo <= to_hi, lo, hi),
+            residual_ms=residual_ms,
+        )
+
+    # ------------------------------------------------------------------- state
+
+    def _side_blocks(  # noqa: C901
+        self, floats: _Floats, ints: _Ints, r: _Resampling
+    ) -> tuple[
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.int32],
+        npt.NDArray[np.bool_],
+    ]:
+        """§6.1: bimanual state blocks plus the `side_valid` mask."""
+        n, n_sides = len(r.grid_ns), len(SIDES)
+        state = np.zeros((n, n_sides, STATE_DIM_QUAT), dtype=np.float64)
+        imu = np.zeros((n, n_sides, IMU_DIM), dtype=np.float64)
+        status = np.zeros((n, n_sides, len(STATUS_SENSORS)), dtype=np.int32)
+        side_valid = np.zeros(n_sides, dtype=bool)
+
+        for side in self._sides_present(floats):
+            s = SIDES.index(side)
+            side_valid[s] = True
+            offset = 0
+            for topic in self._side_topics(side):
+                values = np.asarray(floats[topic], dtype=np.float64)
+                match values.shape[-1]:
+                    case 7:  # §3.3: linear for translations, SLERP for rotations
+                        state[:, s, offset : offset + _POSE_WIDTH] = np.concatenate(
+                            [r.lerp(values[:, :3]), r.slerp(values[:, 3:])], axis=-1
+                        )
+                        offset += _POSE_WIDTH
+
+                    case 4:  # rotation only
+                        state[:, s, offset : offset + _QUAT_WIDTH] = r.slerp(values)
+                        offset += _QUAT_WIDTH
+
+                    case _:
+                        raise RuntimeError
+
+            if self._include_imu:
+                for i, segment in enumerate(IMU_SEGMENTS):
+                    fields = ("angular_velocity", "proper_acceleration")
+                    for j, field in enumerate(fields):
+                        k = (i * len(fields) + j) * 3
+                        imu[:, s, k : k + 3] = r.lerp(
+                            np.asarray(
+                                floats[_topic(side, f"{segment}_imu.{field}")],
+                                dtype=np.float64,
+                            )
+                        )
+
+            if self._include_status_flags:
+                for i, sensor in enumerate(STATUS_SENSORS):
+                    # §2.5: carried through untouched; never interpolated
+                    status[:, s, i] = np.asarray(
+                        ints[_topic(side, f"{sensor}.status_flags")], dtype=np.int32
+                    )[r.nearest, 0]
+
+        if not side_valid.any():
+            logger.error(msg := "no sides present in recording")
+
+            raise ValueError(msg)
+
+        return state, imu, status, side_valid
+
+    def _sides_present(self, floats: _Floats) -> tuple[str, ...]:
+        present = []
+        for side in self._sides:
+            if all(topic in floats for topic in self._side_topics(side)):
+                present.append(side)
+            else:
+                # §6.1: a missing side is zeros + mask, never a dropped column
+                logger.debug("side absent from recording; masking out", side=side)
+
+        return tuple(present)
+
+    @staticmethod
+    def _relative_to_start(
+        state: npt.NDArray[np.float64], side_valid: npt.NDArray[np.bool_]
+    ) -> npt.NDArray[np.float64]:
+        """§4: arm pose and hub orientation relative to the episode's first sample.
+
+        Finger poses are already expressed relative to the glove hub and are left
+        untouched.
+        """
+        out = state.copy()
+        for s in np.flatnonzero(side_valid):
+            r0 = quat_to_matrix(state[0, s, 3:7])
+            out[:, s, :3] = (state[:, s, :3] - state[0, s, :3]) @ r0
+            out[:, s, 3:7] = _quat_relative(state[0, s, 3:7], state[:, s, 3:7])
+            out[:, s, -4:] = _quat_relative(state[0, s, -4:], state[:, s, -4:])
+
+        return out
+
+    # ---------------------------------------------------------- camera columns
+
+    def _frame_index_columns(
+        self, cameras: dict[str, _Camera], r: _Resampling, n: int
+    ) -> dict[str, pl.Series]:
+        """Join every camera on its own `frame_index` (§3, dropped frames)."""
+        grid_ns = r.grid_ns[:n]
+        columns: dict[str, pl.Series] = {}
+        for camera, (frame_index, stream) in cameras.items():
+            name = f"frame_index.{camera}"
+            if camera == self._reference_camera:
+                columns[name] = pl.Series(name, r.frame_index[:n], pl.Int32)
+
+                continue
+
+            other_ns = stream.common_ns
+            j = np.searchsorted(other_ns, grid_ns, side="left").clip(
+                0, len(other_ns) - 1
+            )
+            j_prev = (j - 1).clip(0, len(other_ns) - 1)
+            j = np.where(
+                np.abs(other_ns[j_prev] - grid_ns) < np.abs(other_ns[j] - grid_ns),
+                j_prev,
+                j,
+            )
+            gap_ms = np.abs(other_ns[j] - grid_ns) / _NS_PER_MS
+            if (beyond := int((gap_ms > self._camera_gap_tolerance_ms).sum())) > 0:
+                logger.warning(
+                    "camera frames beyond gap tolerance",
+                    camera=camera,
+                    count=beyond,
+                    max_gap_ms=round(float(gap_ms.max()), 3),
+                )
+
+            columns[name] = pl.Series(name, frame_index[j], pl.Int32)
+
+        return columns
+
+    # ------------------------------------------------------------------- build
+
+    def _build(self, path: Path, calibration_path: Path) -> pl.DataFrame:
+        calibration = NeroArmsCalibration.from_path(calibration_path)
+        floats, ints = self._read(path)
+        glove = self._glove(floats, ints)
+        cameras = self._cameras_from(ints)
+        resampling = self._resample(glove, cameras[self._reference_camera])
+
+        logger.debug(
+            "clock offsets",
+            offset_ns={"glove": glove.offset_ns}
+            | {camera: c.stream.offset_ns for camera, c in cameras.items()},
+            latency_spread_ms={"glove": round(glove.latency_spread_ms, 3)}
+            | {
+                camera: round(c.stream.latency_spread_ms, 3)
+                for camera, c in cameras.items()
+            },
+            offset_drift_ms={"glove": round(glove.offset_drift_ms, 3)}
+            | {
+                camera: round(c.stream.offset_drift_ms, 3)
+                for camera, c in cameras.items()
+            },
+        )
+
+        state, imu, status, side_valid = self._side_blocks(floats, ints, resampling)
+
+        # §6.2: action(t) == states [t+1 .. t+H]; rows without a full chunk are
+        # dropped rather than clamped or wrapped.
+        h = self._action_horizon
+        if (n := len(resampling.grid_ns) - h) <= 0:
+            logger.error(
+                msg := "episode shorter than the action horizon",
+                length=len(resampling.grid_ns),
+                action_horizon=h,
+            )
+
+            raise ValueError(msg)
+
+        future = np.stack([state[i + 1 : i + 1 + h] for i in range(n)])
+
+        # §9: goal is the final arm position / final frame of the episode
+        goal_xyz = np.zeros((len(SIDES), 3), dtype=np.float64)
+        goal_xyz[side_valid] = state[-1, side_valid, :3]
+
+        columns = (
+            self._frame_index_columns(cameras, resampling, n)
+            | {
+                "state.pose": _array("state.pose", state[:n], pl.Float32()),
+                "state.pose_rel_start": _array(
+                    "state.pose_rel_start",
+                    self._relative_to_start(state, side_valid)[:n],
+                    pl.Float32(),
+                ),
+                "action.future_state": _array(
+                    "action.future_state", future, pl.Float32()
+                ),
+                "side_valid": _array(
+                    "side_valid", _repeat(side_valid, n), pl.Boolean()
+                ),
+                "align_residual_ms": pl.Series(
+                    "align_residual_ms", resampling.residual_ms[:n], pl.Float32
+                ),
+                "camera_cond": _array(
+                    "camera_cond",
+                    _repeat(calibration.cond(self._cameras), n),
+                    pl.Float32(),
+                ),
+                "camera_cond.placeholder": pl.Series(
+                    "camera_cond.placeholder",
+                    np.full(n, calibration.placeholder),
+                    pl.Boolean,
+                ),
+                "goal.xyz": _array("goal.xyz", _repeat(goal_xyz, n), pl.Float32()),
+            }
+            | {
+                f"goal.frame_index.{camera}": pl.Series(
+                    f"goal.frame_index.{camera}",
+                    np.full(n, int(camera_.frame_index[-1])),
+                    pl.Int32,
+                )
+                for camera, camera_ in cameras.items()
+            }
+        )
+
+        if self._include_imu:
+            columns["state.imu"] = _array("state.imu", imu[:n], pl.Float32())
+
+        if self._include_status_flags:
+            columns["state.status_flags"] = _array(
+                "state.status_flags", status[:n], pl.Int32()
+            )
+
+        return pl.DataFrame(columns)
+
+
+def _quat_relative(
+    q0: npt.NDArray[np.float64], q: npt.NDArray[np.float64]
+) -> npt.NDArray[np.float64]:
+    """`q0^-1 * q`, canonicalised."""
+    x0, y0, z0, w0 = -q0[0], -q0[1], -q0[2], q0[3]
+    x, y, z, w = q[..., 0], q[..., 1], q[..., 2], q[..., 3]
+
+    return canonicalize_quat(
+        np.stack(
+            [
+                w0 * x + x0 * w + y0 * z - z0 * y,
+                w0 * y - x0 * z + y0 * w + z0 * x,
+                w0 * z + x0 * y - y0 * x + z0 * w,
+                w0 * w - x0 * x - y0 * y - z0 * z,
+            ],
+            axis=-1,
+        )
+    )
+
+
+def _repeat(values: npt.NDArray[np.generic], n: int) -> npt.NDArray[np.generic]:
+    """Broadcast an episode-constant block to one row per sample."""
+    return np.broadcast_to(values, (n, *values.shape))
+
+
+def _nested(dtype: pl.DataType, shape: tuple[int, ...]) -> pl.DataType:
+    for size in reversed(shape):
+        dtype = pl.Array(dtype, size)
+
+    return dtype
+
+
+def _array(name: str, values: npt.NDArray[np.generic], dtype: pl.DataType) -> pl.Series:
+    return pl.Series(name, values.tolist(), _nested(dtype, values.shape[1:]))

--- a/src/rbyte/io/nero/rotation.py
+++ b/src/rbyte/io/nero/rotation.py
@@ -1,0 +1,185 @@
+"""Rotation utilities for the nero-arms data contract (§5).
+
+Quaternions are stored and manipulated in `(qx, qy, qz, qw)` order, matching the
+`Transform` / `Orientation` protobuf field order in the source recordings.
+
+The *storage* form is a canonicalised quaternion (7 floats per pose, §5.2). The
+*model-facing* form is 3 translation + 6D continuous rotation (9 floats per pose,
+§5.3); the conversion helpers live here so that ingestion and the rmind input
+boundary share one implementation.
+"""
+
+from typing import Final
+
+import numpy as np
+import numpy.typing as npt
+
+__all__ = [
+    "POSE_DIM_9D",
+    "POSE_DIM_QUAT",
+    "canonicalize_quat",
+    "pose_9d_to_quat",
+    "pose_quat_to_9d",
+    "quat_slerp",
+    "quat_to_rot6d",
+    "rot6d_to_quat",
+]
+
+POSE_DIM_QUAT: Final = 7
+POSE_DIM_9D: Final = 9
+
+_EPS: Final = 1e-8
+
+
+def canonicalize_quat(q: npt.ArrayLike) -> npt.NDArray[np.float64]:
+    """Remove the quaternion double cover by flipping so that `qw >= 0` (§5.1)."""
+    q = np.asarray(q, dtype=np.float64)
+    return np.where(q[..., 3:4] < 0.0, -q, q)
+
+
+def quat_slerp(
+    q0: npt.ArrayLike, q1: npt.ArrayLike, t: npt.ArrayLike
+) -> npt.NDArray[np.float64]:
+    """Spherical linear interpolation along the shortest arc (§3.3).
+
+    `t` broadcasts against the leading dimensions of `q0`/`q1`.
+    """
+    q0 = np.asarray(q0, dtype=np.float64)
+    q1 = np.asarray(q1, dtype=np.float64)
+    t = np.asarray(t, dtype=np.float64)[..., None]
+
+    dot = np.sum(q0 * q1, axis=-1, keepdims=True)
+    # shortest arc
+    q1 = np.where(dot < 0.0, -q1, q1)
+    dot = np.abs(dot)
+
+    theta = np.arccos(np.clip(dot, -1.0, 1.0))
+    sin_theta = np.sin(theta)
+    colinear = sin_theta < _EPS
+    sin_theta_safe = np.where(colinear, 1.0, sin_theta)
+
+    w0 = np.where(colinear, 1.0 - t, np.sin((1.0 - t) * theta) / sin_theta_safe)
+    w1 = np.where(colinear, t, np.sin(t * theta) / sin_theta_safe)
+
+    q = w0 * q0 + w1 * q1
+    norm = np.linalg.norm(q, axis=-1, keepdims=True)
+
+    return q / np.where(norm < _EPS, 1.0, norm)
+
+
+def quat_to_matrix(q: npt.ArrayLike) -> npt.NDArray[np.float64]:
+    """`(..., 4)` quaternion `(qx, qy, qz, qw)` -> `(..., 3, 3)` rotation matrix."""
+    q = np.asarray(q, dtype=np.float64)
+    norm = np.linalg.norm(q, axis=-1, keepdims=True)
+    x, y, z, w = np.moveaxis(q / np.where(norm < _EPS, 1.0, norm), -1, 0)
+
+    return np.stack(
+        [
+            1 - 2 * (y * y + z * z),
+            2 * (x * y - z * w),
+            2 * (x * z + y * w),
+            2 * (x * y + z * w),
+            1 - 2 * (x * x + z * z),
+            2 * (y * z - x * w),
+            2 * (x * z - y * w),
+            2 * (y * z + x * w),
+            1 - 2 * (x * x + y * y),
+        ],
+        axis=-1,
+    ).reshape(*q.shape[:-1], 3, 3)
+
+
+def matrix_to_quat(m: npt.ArrayLike) -> npt.NDArray[np.float64]:
+    """`(..., 3, 3)` rotation matrix -> canonicalised `(..., 4)` quaternion."""
+    m = np.asarray(m, dtype=np.float64)
+    trace = m[..., 0, 0] + m[..., 1, 1] + m[..., 2, 2]
+
+    # branchless Shepperd: build all four candidates, pick the numerically largest
+    candidates = np.stack(
+        [
+            np.stack(
+                [
+                    1.0 + trace,
+                    m[..., 2, 1] - m[..., 1, 2],
+                    m[..., 0, 2] - m[..., 2, 0],
+                    m[..., 1, 0] - m[..., 0, 1],
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    m[..., 2, 1] - m[..., 1, 2],
+                    1.0 + m[..., 0, 0] - m[..., 1, 1] - m[..., 2, 2],
+                    m[..., 0, 1] + m[..., 1, 0],
+                    m[..., 0, 2] + m[..., 2, 0],
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    m[..., 0, 2] - m[..., 2, 0],
+                    m[..., 0, 1] + m[..., 1, 0],
+                    1.0 - m[..., 0, 0] + m[..., 1, 1] - m[..., 2, 2],
+                    m[..., 1, 2] + m[..., 2, 1],
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    m[..., 1, 0] - m[..., 0, 1],
+                    m[..., 0, 2] + m[..., 2, 0],
+                    m[..., 1, 2] + m[..., 2, 1],
+                    1.0 - m[..., 0, 0] - m[..., 1, 1] + m[..., 2, 2],
+                ],
+                axis=-1,
+            ),
+        ],
+        axis=-2,
+    )
+    # (..., 4 candidates, 4 components) in (w, x, y, z) order
+    best = np.argmax(np.abs(candidates[..., 0]), axis=-1)
+    wxyz = np.take_along_axis(candidates, best[..., None, None], axis=-2)[..., 0, :]
+    norm = np.linalg.norm(wxyz, axis=-1, keepdims=True)
+    wxyz /= np.where(norm < _EPS, 1.0, norm)
+
+    return canonicalize_quat(np.roll(wxyz, -1, axis=-1))
+
+
+def quat_to_rot6d(q: npt.ArrayLike) -> npt.NDArray[np.float64]:
+    """`(..., 4)` quaternion -> `(..., 6)` continuous rotation (Zhou et al., §5.3).
+
+    The 6D representation is the first two *columns* of the rotation matrix.
+    """
+    m = quat_to_matrix(q)
+
+    return np.concatenate([m[..., 0], m[..., 1]], axis=-1)
+
+
+def rot6d_to_quat(r: npt.ArrayLike) -> npt.NDArray[np.float64]:
+    """`(..., 6)` continuous rotation -> canonicalised `(..., 4)` quaternion."""
+    r = np.asarray(r, dtype=np.float64)
+    a, b = r[..., :3], r[..., 3:]
+
+    norm_a = np.linalg.norm(a, axis=-1, keepdims=True)
+    e0 = a / np.where(norm_a < _EPS, 1.0, norm_a)
+    # not in-place: `b` is a view onto the caller's array
+    b = b - np.sum(e0 * b, axis=-1, keepdims=True) * e0  # noqa: PLR6104
+    norm_b = np.linalg.norm(b, axis=-1, keepdims=True)
+    e1 = b / np.where(norm_b < _EPS, 1.0, norm_b)
+    e2 = np.cross(e0, e1)
+
+    return matrix_to_quat(np.stack([e0, e1, e2], axis=-1))
+
+
+def pose_quat_to_9d(pose: npt.ArrayLike) -> npt.NDArray[np.float64]:
+    """`(..., 7)` `(x, y, z, qx, qy, qz, qw)` -> `(..., 9)` `(xyz, rot6d)` (§5.3)."""
+    pose = np.asarray(pose, dtype=np.float64)
+
+    return np.concatenate([pose[..., :3], quat_to_rot6d(pose[..., 3:])], axis=-1)
+
+
+def pose_9d_to_quat(pose: npt.ArrayLike) -> npt.NDArray[np.float64]:
+    """`(..., 9)` `(xyz, rot6d)` -> `(..., 7)` `(x, y, z, qx, qy, qz, qw)` (§5.3)."""
+    pose = np.asarray(pose, dtype=np.float64)
+
+    return np.concatenate([pose[..., :3], rot6d_to_quat(pose[..., 3:])], axis=-1)

--- a/src/rbyte/io/nero/schema.py
+++ b/src/rbyte/io/nero/schema.py
@@ -1,0 +1,98 @@
+"""Layout constants for the nero-arms state/action vectors (data contract §6).
+
+Storage form (what rbyte emits, §5.2) packs, per side:
+
+| slice     | block                             | poses | dims |
+|-----------|-----------------------------------|-------|------|
+| `[0:7]`   | arm in the coil-pro world frame   | 1     | 7    |
+| `[7:42]`  | finger tips relative to the hub   | 5     | 35   |
+| `[42:46]` | hub orientation (rotation only)   | 1     | 4    |
+
+giving `STATE_DIM_QUAT == 46` per side. `state_quat_to_9d` maps this onto the
+model-facing 60-dim 9D form of §6.1 (arm 9 + fingers 45 + hub rotation 6).
+"""
+
+from typing import Final
+
+import numpy as np
+import numpy.typing as npt
+
+from rbyte.io.nero.rotation import (
+    pose_9d_to_quat,
+    pose_quat_to_9d,
+    quat_to_rot6d,
+    rot6d_to_quat,
+)
+
+__all__ = [
+    "CAMERAS",
+    "FINGERS",
+    "IMU_DIM",
+    "IMU_SEGMENTS",
+    "SIDES",
+    "STATE_DIM_9D",
+    "STATE_DIM_QUAT",
+    "STATUS_SENSORS",
+    "state_9d_to_quat",
+    "state_quat_to_9d",
+]
+
+SIDES: Final = ("left", "right")
+FINGERS: Final = ("thumb", "index", "middle", "ring", "little")
+CAMERAS: Final = ("base", "side_left", "side_right")
+
+#: §6.1 auxiliary block: 7 segments x (angular_velocity + proper_acceleration).
+IMU_SEGMENTS: Final = (
+    "hub",
+    "arm",
+    "thumb_finger",
+    "index_finger",
+    "middle_finger",
+    "ring_finger",
+    "little_finger",
+)
+IMU_DIM: Final = len(IMU_SEGMENTS) * 6
+
+#: §2.5 auxiliary block. NOTE: the recordings carry **8** `status_flags` topics per
+#: side, not the 7 quoted in the §8 schema table -- `arm_sensor.coil_pro` and
+#: `arm_sensor` both publish one. §2.5 says "do not drop", so all 8 are carried.
+STATUS_SENSORS: Final = (
+    "arm_sensor.coil_pro",
+    "arm_sensor",
+    "hub",
+    *(f"{finger}_finger_sensor" for finger in FINGERS),
+)
+
+_N_POSES: Final = 1 + len(FINGERS)
+STATE_DIM_QUAT: Final = _N_POSES * 7 + 4
+STATE_DIM_9D: Final = _N_POSES * 9 + 6
+
+
+def state_quat_to_9d(state: npt.ArrayLike) -> npt.NDArray[np.float64]:
+    """`(..., 46)` storage state -> `(..., 60)` model-facing 9D state (§6.1)."""
+    state = np.asarray(state, dtype=np.float64)
+    poses = state[..., : _N_POSES * 7].reshape(*state.shape[:-1], _N_POSES, 7)
+    hub = state[..., _N_POSES * 7 :]
+
+    return np.concatenate(
+        [
+            pose_quat_to_9d(poses).reshape(*state.shape[:-1], _N_POSES * 9),
+            quat_to_rot6d(hub),
+        ],
+        axis=-1,
+    )
+
+
+def state_9d_to_quat(state: npt.ArrayLike) -> npt.NDArray[np.float64]:
+    """`(..., 60)` model-facing 9D state -> `(..., 46)` storage state (§6.1)."""
+    state = np.asarray(state, dtype=np.float64)
+    poses = state[..., : _N_POSES * 9].reshape(*state.shape[:-1], _N_POSES, 9)
+    hub = state[..., _N_POSES * 9 :]
+
+    return np.concatenate(
+        [
+            pose_9d_to_quat(poses).reshape(*state.shape[:-1], _N_POSES * 7),
+            rot6d_to_quat(hub),
+        ],
+        axis=-1,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,6 @@ from rbyte.io import (
     TreeBroadcastMapper,
     VideoDataFrameBuilder,
     WaypointBuilder,
-    YaakMetadataDataFrameBuilder,
 )
 from rbyte.io.dataframe.aligner import (
     AlignConfig,
@@ -32,6 +31,19 @@ from rbyte.io.dataframe.aligner import (
 )
 from rbyte.io.dataframe.concater import DataFrameConcater
 from rbyte.viz.loggers.rerun_logger import RerunLogger
+
+# `rbyte.io` exports this only when the generated yaak protobuf stubs are
+# present -- they require the private `idl-repo` submodule (see `just setup`).
+# Mirror that optionality here so the rest of the suite stays collectable.
+try:
+    from rbyte.io import YaakMetadataDataFrameBuilder
+except ImportError:
+    YaakMetadataDataFrameBuilder = None
+
+requires_yaak_proto = pytest.mark.skipif(
+    YaakMetadataDataFrameBuilder is None,
+    reason="yaak protobuf stubs unavailable (see `just setup`)",
+)
 
 logger = get_logger(__name__)
 
@@ -66,6 +78,9 @@ def nuscenes_dataset() -> Dataset:
 
 @pytest.fixture(scope="session")
 def yaak_dataset() -> Dataset:
+    if YaakMetadataDataFrameBuilder is None:
+        pytest.skip("yaak protobuf stubs unavailable")
+
     return _build_dataset("yaak")
 
 
@@ -76,6 +91,9 @@ def zod_dataset() -> Dataset:
 
 @pytest.fixture(scope="session")
 def yaak_dataset_pydantic() -> Dataset:
+    if YaakMetadataDataFrameBuilder is None:
+        pytest.skip("yaak protobuf stubs unavailable")
+
     data_dir = DATA_DIR / "yaak"
     drive_queries: dict[str, str] = {
         "Niro098-HQ/2024-06-18--13-39-54": "SELECT * FROM self WHERE time_stamp BETWEEN TIMESTAMP('2024-06-18 13:39:55') AND TIMESTAMP('2024-06-18 13:40:15')"  # noqa: E501

--- a/tests/data/nero_arms/calibration.yaml
+++ b/tests/data/nero_arms/calibration.yaml
@@ -1,0 +1,48 @@
+# nero-arms camera calibration sidecar (data contract §7).
+#
+# Canonical location is the recording-session directory, e.g.
+#   ${data_dir}/calibration.yaml
+# so that real calibration is a plain file drop. This copy is the placeholder
+# that ships with rbyte for tests and as a template.
+#
+# `image_size` is MEASURED (§7.2) -- the three cameras are heterogeneous.
+# Everything else is a PLACEHOLDER and `placeholder: true` must be flipped to
+# false before any real training run.
+---
+version: 0
+world_frame: coil_pro # extrinsics are expressed in the coil-pro base-station frame
+cameras:
+  base:
+    model: opencv_fisheye # one of: pinhole | opencv | opencv_fisheye (Kannala-Brandt)
+    image_size: [1920, 1080] # MEASURED
+    intrinsics: {fx: 0.0, fy: 0.0, cx: 0.0, cy: 0.0} # PLACEHOLDER
+    distortion: [0.0, 0.0, 0.0, 0.0] # PLACEHOLDER, k1..k4
+    T_world_cam: # PLACEHOLDER 4x4
+      - [1.0, 0.0, 0.0, 0.0]
+      - [0.0, 1.0, 0.0, 0.0]
+      - [0.0, 0.0, 1.0, 0.0]
+      - [0.0, 0.0, 0.0, 1.0]
+
+  side_left:
+    model: opencv_fisheye
+    image_size: [1280, 800] # MEASURED
+    intrinsics: {fx: 0.0, fy: 0.0, cx: 0.0, cy: 0.0} # PLACEHOLDER
+    distortion: [0.0, 0.0, 0.0, 0.0] # PLACEHOLDER
+    T_world_cam: # PLACEHOLDER
+      - [1.0, 0.0, 0.0, 0.0]
+      - [0.0, 1.0, 0.0, 0.0]
+      - [0.0, 0.0, 1.0, 0.0]
+      - [0.0, 0.0, 0.0, 1.0]
+
+  side_right:
+    model: opencv_fisheye
+    image_size: [1280, 800] # MEASURED
+    intrinsics: {fx: 0.0, fy: 0.0, cx: 0.0, cy: 0.0} # PLACEHOLDER
+    distortion: [0.0, 0.0, 0.0, 0.0] # PLACEHOLDER
+    T_world_cam: # PLACEHOLDER
+      - [1.0, 0.0, 0.0, 0.0]
+      - [0.0, 1.0, 0.0, 0.0]
+      - [0.0, 0.0, 1.0, 0.0]
+      - [0.0, 0.0, 0.0, 1.0]
+
+placeholder: true # MUST be false before any real training run

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,7 +3,9 @@ from pathlib import Path
 import polars as pl
 from polars.testing import assert_frame_equal
 
-from rbyte.io import PathDataFrameBuilder, YaakMetadataDataFrameBuilder
+from rbyte.io import PathDataFrameBuilder
+
+from .conftest import YaakMetadataDataFrameBuilder, requires_yaak_proto
 
 DATA_DIR = Path(__file__).resolve().parent / "data"
 CAMERA_ENUM = pl.Enum(
@@ -45,6 +47,7 @@ def test_PathDataFrameBuilder() -> None:  # noqa: N802
     )
 
 
+@requires_yaak_proto
 def test_YaakMetadataDataFrameBuilder() -> None:  # noqa: N802
     path = DATA_DIR / "yaak" / "Niro098-HQ" / "2024-06-18--13-39-54" / "metadata.log"
 

--- a/tests/test_nero.py
+++ b/tests/test_nero.py
@@ -1,0 +1,442 @@
+"""Tests for the nero-arms ingestion (data contract v0.1).
+
+The unit tests below are self-contained. The end-to-end schema test needs the
+recording share and is skipped when it is not mounted -- the dummy recordings
+are ~2.4 GB and are deliberately not vendored into `tests/data`.
+"""
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import polars as pl
+import pytest
+
+from rbyte.io.nero import (
+    CAMERA_COND_DIM,
+    CAMERAS,
+    IMU_DIM,
+    SIDES,
+    STATE_DIM_9D,
+    STATE_DIM_QUAT,
+    STATUS_SENSORS,
+    NeroArmsCalibration,
+    NeroArmsDataFrameBuilder,
+    canonicalize_quat,
+    pose_9d_to_quat,
+    pose_quat_to_9d,
+    quat_slerp,
+    quat_to_rot6d,
+    rot6d_to_quat,
+    state_9d_to_quat,
+    state_quat_to_9d,
+)
+from rbyte.io.nero.rotation import matrix_to_quat, quat_to_matrix
+
+DATA_DIR = Path(__file__).resolve().parent / "data" / "nero_arms"
+CALIBRATION_PATH = DATA_DIR / "calibration.yaml"
+
+#: the recording session root; override with `NERO_ARMS_DATA_DIR`
+SESSION_DIR = Path(
+    os.environ.get(
+        "NERO_ARMS_DATA_DIR", "/nasa/drives/nero-arms/gloves-mcap-recordings/2026-07-17"
+    )
+)
+
+#: §3.4: one glove period at 83.4 Hz
+GLOVE_PERIOD_MS = 12.0
+#: §2.5 status-flag channels per side actually present in the recordings
+N_STATUS_SENSORS = 8
+#: half a glove period -- the worst possible distance to a bracketing sample
+GLOVE_HALF_PERIOD_MS = GLOVE_PERIOD_MS / 2
+
+
+def _random_quats(n: int, *, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    q = rng.standard_normal((n, 4))
+
+    return q / np.linalg.norm(q, axis=-1, keepdims=True)
+
+
+# --------------------------------------------------------------- §5 rotations
+
+
+def test_canonicalize_quat_flips_negative_qw() -> None:
+    q = _random_quats(256)
+    canonical = canonicalize_quat(q)
+
+    assert (canonical[:, 3] >= 0.0).all(), "qw must be non-negative after §5.1"
+    # q and -q are the same rotation
+    assert np.allclose(np.abs(np.sum(canonical * q, axis=-1)), 1.0)
+    # idempotent
+    assert np.array_equal(canonicalize_quat(canonical), canonical)
+
+
+def test_canonicalize_quat_preserves_rotation() -> None:
+    q = _random_quats(64, seed=1)
+
+    assert np.allclose(quat_to_matrix(q), quat_to_matrix(canonicalize_quat(q)))
+
+
+def test_quat_rot6d_roundtrip() -> None:
+    q = canonicalize_quat(_random_quats(256, seed=2))
+    r6 = quat_to_rot6d(q)
+
+    assert r6.shape == (256, 6)
+    assert np.allclose(rot6d_to_quat(r6), q, atol=1e-9)
+
+
+def test_rot6d_is_first_two_columns_of_r() -> None:
+    q = canonicalize_quat(_random_quats(16, seed=3))
+    m = quat_to_matrix(q)
+
+    assert np.allclose(quat_to_rot6d(q), np.concatenate([m[:, :, 0], m[:, :, 1]], -1))
+
+
+def test_identity_rotation_6d() -> None:
+    identity = np.array([0.0, 0.0, 0.0, 1.0])
+
+    assert np.allclose(quat_to_rot6d(identity), [1, 0, 0, 0, 1, 0])
+
+
+def test_pose_and_state_roundtrip() -> None:
+    rng = np.random.default_rng(4)
+    pose = np.concatenate(
+        [rng.standard_normal((32, 3)), canonicalize_quat(_random_quats(32, seed=5))], -1
+    )
+
+    assert pose_quat_to_9d(pose).shape == (32, 9)
+    assert np.allclose(pose_9d_to_quat(pose_quat_to_9d(pose)), pose, atol=1e-9)
+
+    state = np.concatenate(
+        [
+            np.concatenate(
+                [
+                    rng.standard_normal((8, 3)),
+                    canonicalize_quat(_random_quats(8, seed=6 + i)),
+                ],
+                -1,
+            )
+            for i in range(6)
+        ]
+        + [canonicalize_quat(_random_quats(8, seed=99))],
+        axis=-1,
+    )
+
+    assert state.shape == (8, STATE_DIM_QUAT)
+    assert state_quat_to_9d(state).shape == (8, STATE_DIM_9D)
+    assert np.allclose(state_9d_to_quat(state_quat_to_9d(state)), state, atol=1e-9)
+
+
+def test_matrix_quat_roundtrip() -> None:
+    q = canonicalize_quat(_random_quats(256, seed=7))
+
+    assert np.allclose(matrix_to_quat(quat_to_matrix(q)), q, atol=1e-9)
+
+
+# ------------------------------------------------------------------ §3 slerp
+
+
+def test_quat_slerp_endpoints_and_midpoint() -> None:
+    q0 = canonicalize_quat(_random_quats(64, seed=8))
+    q1 = canonicalize_quat(_random_quats(64, seed=9))
+
+    assert np.allclose(np.abs(np.sum(quat_slerp(q0, q1, np.zeros(64)) * q0, -1)), 1.0)
+    assert np.allclose(np.abs(np.sum(quat_slerp(q0, q1, np.ones(64)) * q1, -1)), 1.0)
+
+    mid = quat_slerp(q0, q1, np.full(64, 0.5))
+
+    assert np.allclose(np.linalg.norm(mid, axis=-1), 1.0), "slerp must stay on S3"
+    # equidistant from both endpoints
+    angle_0 = np.arccos(np.clip(np.abs(np.sum(mid * q0, -1)), -1, 1))
+    angle_1 = np.arccos(np.clip(np.abs(np.sum(mid * q1, -1)), -1, 1))
+
+    assert np.allclose(angle_0, angle_1, atol=1e-9)
+
+
+def test_quat_slerp_takes_the_shortest_arc() -> None:
+    q0 = canonicalize_quat(_random_quats(64, seed=10))
+    q1 = canonicalize_quat(_random_quats(64, seed=11))
+    t = np.random.default_rng(12).uniform(size=64)
+
+    # slerping to -q1 must give the same rotation as slerping to q1
+    assert np.allclose(
+        quat_to_matrix(quat_slerp(q0, q1, t)), quat_to_matrix(quat_slerp(q0, -q1, t))
+    )
+
+
+def test_quat_slerp_is_not_nearest_neighbour() -> None:
+    """A 90 degree rotation interpolated at t=0.5 must land at 45 degrees."""
+    q0 = np.array([0.0, 0.0, 0.0, 1.0])
+    q1 = np.array([0.0, 0.0, np.sin(np.pi / 4), np.cos(np.pi / 4)])
+    mid = quat_slerp(q0, q1, np.array(0.5))
+
+    assert np.allclose(mid, [0.0, 0.0, np.sin(np.pi / 8), np.cos(np.pi / 8)])
+
+
+def test_quat_slerp_handles_identical_endpoints() -> None:
+    q = canonicalize_quat(_random_quats(16, seed=13))
+    out = quat_slerp(q, q, np.full(16, 0.3))
+
+    assert np.isfinite(out).all()
+    assert np.allclose(out, q)
+
+
+# ------------------------------------------------------------ §7 calibration
+
+
+def test_calibration_placeholder() -> None:
+    calibration = NeroArmsCalibration.from_path(CALIBRATION_PATH)
+
+    assert calibration.placeholder, "shipped calibration must be flagged placeholder"
+    assert set(calibration.cameras) == set(CAMERAS)
+    # §7.2: the cameras are heterogeneous
+    assert calibration.cameras["base"].image_size == (1920, 1080)
+    assert calibration.cameras["side_left"].image_size == (1280, 800)
+    assert calibration.cameras["side_right"].image_size == (1280, 800)
+
+
+def test_camera_cond_shape_and_identity_extrinsics() -> None:
+    cond = NeroArmsCalibration.from_path(CALIBRATION_PATH).cond(CAMERAS)
+
+    assert cond.shape == (len(CAMERAS), CAMERA_COND_DIM)
+    assert cond.dtype == np.float32
+
+    for row in cond:
+        # placeholder intrinsics are zero, and normalising by W/H keeps them zero
+        assert np.allclose(row[:4], 0.0)
+        assert np.allclose(row[4:7], 0.0), "placeholder translation is the origin"
+        # identity rotation as 6D -- not all-zero, so assert on it exactly
+        assert np.allclose(row[7:], [1, 0, 0, 0, 1, 0])
+
+
+def test_camera_cond_is_resolution_normalised() -> None:
+    """Isotropic resize must leave the conditioning vector unchanged (§7.1)."""
+    calibration = NeroArmsCalibration.from_path(CALIBRATION_PATH)
+    camera = calibration.cameras["base"].model_copy(deep=True)
+    camera.intrinsics.fx = 960.0
+    camera.intrinsics.fy = 960.0
+    camera.intrinsics.cx = 960.0
+    camera.intrinsics.cy = 540.0
+    cond = camera.cond
+
+    scaled = camera.model_copy(deep=True)
+    scaled.image_size = (480, 270)
+    for field in ("fx", "fy", "cx", "cy"):
+        setattr(scaled.intrinsics, field, getattr(scaled.intrinsics, field) * 0.25)
+
+    assert np.allclose(cond, scaled.cond)
+
+
+# ------------------------------------------------------- §6 schema / topology
+
+
+def test_state_dims_match_the_contract() -> None:
+    # §5.2 storage form: 6 poses x 7 + hub orientation quaternion
+    assert STATE_DIM_QUAT == 6 * 7 + 4
+    # §6.1 model-facing form: arm 9 + fingers 45 + hub rotation 6
+    assert STATE_DIM_9D == 9 + 45 + 6
+    assert IMU_DIM == 7 * 6
+    assert SIDES == ("left", "right"), "index 0 is left, index 1 is right"
+    # NOTE: §8 quotes 7 status-flag channels; the recordings carry 8 (§2.5 says
+    # do not drop, so all 8 are carried). See the summary in the PR description.
+    assert len(STATUS_SENSORS) == N_STATUS_SENSORS
+
+
+def test_builder_rejects_unknown_reference_camera() -> None:
+    with pytest.raises(ValueError, match="reference_camera"):
+        NeroArmsDataFrameBuilder(cameras=["base"], reference_camera="side_left")
+
+
+# ---------------------------------------------------------------- end to end
+
+_EPISODES = (
+    sorted(p.name for p in SESSION_DIR.iterdir() if (p / "data.mcap").is_file())
+    if SESSION_DIR.is_dir()
+    else []
+)
+
+requires_session = pytest.mark.skipif(
+    not _EPISODES, reason=f"nero-arms recording session not mounted at {SESSION_DIR}"
+)
+
+
+@pytest.fixture(scope="session")
+def nero_arms_dataframe() -> pl.DataFrame:
+    builder = NeroArmsDataFrameBuilder(include_imu=True, include_status_flags=True)
+
+    return builder(
+        SESSION_DIR / _EPISODES[0] / "data.mcap", SESSION_DIR / "calibration.yaml"
+    )
+
+
+@requires_session
+def test_dataframe_schema(nero_arms_dataframe: pl.DataFrame) -> None:
+    c = SimpleNamespace(
+        S=len(SIDES), D=STATE_DIM_QUAT, H=6, C=len(CAMERAS), K=CAMERA_COND_DIM
+    )
+
+    assert nero_arms_dataframe.schema == pl.Schema({
+        "frame_index.base": pl.Int32,
+        "frame_index.side_left": pl.Int32,
+        "frame_index.side_right": pl.Int32,
+        "state.pose": pl.Array(pl.Float32, (c.S, c.D)),
+        "state.pose_rel_start": pl.Array(pl.Float32, (c.S, c.D)),
+        "action.future_state": pl.Array(pl.Float32, (c.H, c.S, c.D)),
+        "side_valid": pl.Array(pl.Boolean, (c.S,)),
+        "align_residual_ms": pl.Float32,
+        "camera_cond": pl.Array(pl.Float32, (c.C, c.K)),
+        "camera_cond.placeholder": pl.Boolean,
+        "goal.xyz": pl.Array(pl.Float32, (c.S, 3)),
+        "goal.frame_index.base": pl.Int32,
+        "goal.frame_index.side_left": pl.Int32,
+        "goal.frame_index.side_right": pl.Int32,
+        "state.imu": pl.Array(pl.Float32, (c.S, IMU_DIM)),
+        "state.status_flags": pl.Array(pl.Int32, (c.S, len(STATUS_SENSORS))),
+    })
+
+
+@requires_session
+def test_alignment_residual_within_one_glove_period(
+    nero_arms_dataframe: pl.DataFrame,
+) -> None:
+    residual = nero_arms_dataframe["align_residual_ms"]
+
+    assert residual.null_count() == 0, "no extrapolation: rows must be dropped instead"
+    assert float(residual.min()) >= 0.0
+    # §3.4: fail loudly above one glove period. Measured over all 104 episodes
+    # the worst case is 6.47 ms and the mean is 3.00 ms.
+    assert float(residual.max()) < GLOVE_PERIOD_MS, (
+        f"alignment residual {residual.max()} ms exceeds one glove period"
+    )
+    assert float(residual.mean() or 0.0) < GLOVE_HALF_PERIOD_MS, (
+        "mean residual should sit well inside half a glove period"
+    )
+
+
+@requires_session
+def test_quaternions_are_canonical(nero_arms_dataframe: pl.DataFrame) -> None:
+    state = nero_arms_dataframe["state.pose"].to_numpy()
+    right = state[:, SIDES.index("right")]
+    # 6 poses of 7, then a bare quaternion
+    qw = np.concatenate([right[:, 6:42:7], right[:, -1:]], axis=-1)
+
+    assert (qw >= 0.0).all(), "§5.1: qw must be non-negative after ingestion"
+
+    quats = np.concatenate(
+        [right[:, :42].reshape(-1, 6, 7)[..., 3:], right[:, None, 42:]], axis=1
+    )
+
+    assert np.allclose(np.linalg.norm(quats, axis=-1), 1.0, atol=1e-5)
+
+
+@requires_session
+def test_missing_side_is_zeros_plus_mask(nero_arms_dataframe: pl.DataFrame) -> None:
+    left, right = SIDES.index("left"), SIDES.index("right")
+    side_valid = nero_arms_dataframe["side_valid"].to_numpy()
+
+    assert (side_valid == [False, True]).all(), (
+        "the dummy is right-hand only; left must be masked out, not dropped"
+    )
+
+    for column in ("state.pose", "state.pose_rel_start", "state.imu", "goal.xyz"):
+        values = nero_arms_dataframe[column].to_numpy()
+
+        assert (values[:, left] == 0).all(), f"{column}: masked side must be zeros"
+        assert values[:, right].any(), f"{column}: valid side must not be all-zero"
+
+    assert (nero_arms_dataframe["state.status_flags"].to_numpy()[:, left] == 0).all()
+
+
+@requires_session
+def test_pose_rel_start_is_zero_at_the_first_frame(
+    nero_arms_dataframe: pl.DataFrame,
+) -> None:
+    right = SIDES.index("right")
+    first = nero_arms_dataframe["state.pose_rel_start"].to_numpy()[0, right]
+
+    assert np.allclose(first[:3], 0.0, atol=1e-6), "arm translation is start-relative"
+    assert np.allclose(first[3:7], [0, 0, 0, 1], atol=1e-6), "arm rotation is identity"
+    assert np.allclose(first[-4:], [0, 0, 0, 1], atol=1e-6), "hub rotation is identity"
+    # fingers are already hub-relative and must be left untouched
+    assert np.allclose(
+        first[7:42], nero_arms_dataframe["state.pose"].to_numpy()[0, right, 7:42]
+    )
+
+
+@requires_session
+def test_action_is_the_future_state_chunk(nero_arms_dataframe: pl.DataFrame) -> None:
+    state = nero_arms_dataframe["state.pose"].to_numpy()
+    future = nero_arms_dataframe["action.future_state"].to_numpy()
+    horizon = future.shape[1]
+
+    assert len(state) > horizon
+
+    for h in range(horizon):
+        # action(t)[h] == state(t + 1 + h); the last H rows are dropped, so the
+        # comparison is exact for every emitted row
+        assert np.array_equal(
+            future[: len(state) - horizon, h], state[1 + h :][: len(state) - horizon]
+        ), f"action.future_state[:, {h}] is not state[t + {1 + h}]"
+
+
+@requires_session
+def test_cameras_are_joined_on_their_own_frame_index(
+    nero_arms_dataframe: pl.DataFrame,
+) -> None:
+    df = nero_arms_dataframe
+
+    # the reference camera indexes the grid and must be strictly increasing
+    assert df["frame_index.base"].is_sorted(descending=False)
+    assert int(df["frame_index.base"].diff().drop_nulls().min()) >= 1  # ty: ignore[invalid-argument-type]
+
+    # the sides are matched independently and may legitimately disagree with the
+    # reference index -- 200 vs 201 frames, §3
+    for camera in ("side_left", "side_right"):
+        assert int(df[f"frame_index.{camera}"].min()) >= 0  # ty: ignore[invalid-argument-type]
+        assert df[f"frame_index.{camera}"].is_sorted(descending=False)
+
+
+@requires_session
+def test_goal_is_the_final_frame_and_final_arm_position(
+    nero_arms_dataframe: pl.DataFrame,
+) -> None:
+    df = nero_arms_dataframe
+
+    for camera in CAMERAS:
+        goal = df[f"goal.frame_index.{camera}"]
+
+        assert goal.n_unique() == 1, "§9: goal is constant within an episode"
+        assert goal[0] >= df[f"frame_index.{camera}"].max()
+
+    goal_xyz = df["goal.xyz"].to_numpy()
+
+    assert (goal_xyz == goal_xyz[0]).all(), "§9: goal is constant within an episode"
+
+
+@requires_session
+def test_calibration_placeholder_is_visible_per_sample(
+    nero_arms_dataframe: pl.DataFrame,
+) -> None:
+    placeholder = nero_arms_dataframe["camera_cond.placeholder"]
+
+    assert placeholder.all(), (
+        "consumers must be able to assert on `placeholder` from a batch (§7)"
+    )
+
+
+@requires_session
+def test_episode_lengths_are_not_uniform() -> None:
+    """§1: episode length varies; nothing may assume a fixed length."""
+    builder = NeroArmsDataFrameBuilder()
+    lengths = {
+        episode: len(
+            builder(
+                SESSION_DIR / episode / "data.mcap", SESSION_DIR / "calibration.yaml"
+            )
+        )
+        for episode in _EPISODES[:8]
+    }
+
+    assert len(set(lengths.values())) > 1, f"expected varying lengths, got {lengths}"

--- a/tests/test_nero.py
+++ b/tests/test_nero.py
@@ -304,13 +304,13 @@ def test_alignment_residual_within_one_glove_period(
     residual = nero_arms_dataframe["align_residual_ms"]
 
     assert residual.null_count() == 0, "no extrapolation: rows must be dropped instead"
-    assert float(residual.min()) >= 0.0
+    assert float(residual.min()) >= 0.0  # ty: ignore[invalid-argument-type]
     # §3.4: fail loudly above one glove period. Measured over all 104 episodes
     # the worst case is 6.47 ms and the mean is 3.00 ms.
-    assert float(residual.max()) < GLOVE_PERIOD_MS, (
+    assert float(residual.max()) < GLOVE_PERIOD_MS, (  # ty: ignore[invalid-argument-type]
         f"alignment residual {residual.max()} ms exceeds one glove period"
     )
-    assert float(residual.mean() or 0.0) < GLOVE_HALF_PERIOD_MS, (
+    assert float(residual.mean() or 0.0) < GLOVE_HALF_PERIOD_MS, (  # ty: ignore[invalid-argument-type]
         "mean residual should sit well inside half a glove period"
     )
 


### PR DESCRIPTION
Ingestion for **nero-arms**, a new bimanual robot-manipulation dataset: MCAP glove/robot streams plus three cameras, aligned onto a 30 Hz grid and emitted as an rbyte dataset.

Both sides of this work code against a shared contract at `nero-arms/DATA_CONTRACT.md`, derived empirically from the recordings rather than assumed. The matching policy work is [rmind#267](https://github.com/yaak-ai/rmind/pull/267).

**Verified: 15,047 samples across 104 episodes** (99–278 per episode), reproduced independently from the raw MCAP.

## What's here

| file | what |
|---|---|
| `src/rbyte/io/nero/dataframe_builder.py` | `NeroArmsDataFrameBuilder` — MCAP → 30 Hz camera-grid dataframe |
| `src/rbyte/io/nero/rotation.py` | `canonicalize_quat`, `quat_slerp`, `quat_to_rot6d`/`rot6d_to_quat`, `pose_quat_to_9d`/`pose_9d_to_quat` |
| `src/rbyte/io/nero/schema.py` | layout constants + `state_quat_to_9d` (46→60) |
| `src/rbyte/io/nero/calibration.py` | camera calibration sidecar loader + the 13-dim `camera_cond` vector |
| `config/_templates/dataset/nero_arms.yaml` | full pipeline over all 104 episodes, rooted at `${data_dir}` |
| `tests/test_nero.py` | 26 tests |

## The decisions worth reviewing

**Alignment uses device clocks, never `log_time`.** Measured on the recordings: `log_time`, `publish_time` and `host_arrival_time_ns` all carry 10–35 ms of transport jitter and disagree with each other, while the `device_timestamp_*` fields are clean and monotonic — cameras at 33.333 ms ±0.0005, gloves at 11.987 ms ±0.14. Cross-device offsets are estimated with a **minimum-latency** estimator, since the mean is biased by exactly that jitter.

Measured result over all 104 episodes: `align_residual_ms` mean 3.00, **max 6.47** against a 12 ms hard-fail. 82 rows total (≤2 per episode) were unbracketed and **dropped rather than extrapolated**. The margin is thinner than it looks — 6.47 ms is over half a glove period — so the fail-loud check may well fire on real teleop.

**Rotations are SLERPed, never nearest-neighboured**, and quaternions are canonicalised to `qw ≥ 0` at ingestion. That last one is load-bearing: `qw < 0` in 20.1% of samples on average and up to 40.2% in some episodes, and since `q ≡ −q` any downstream quantiser would otherwise burn codebook capacity learning the sign flip.

**The schema is bimanual with a `side_valid` mask**, even though the dummy recordings are right-hand-only (`[False, True]`). The real rig is bimanual with one arm optionally absent, so this is permanent contract rather than scaffolding — a right-only schema would break on the first real recording.

**Per-camera *isotropic* downscale, not letterbox.** The three cameras are heterogeneous — `base` is 1920×1080, the sides are 1280×800 — so the emitted tensors do **not** share H/W (`base` 270×480, sides 300×480). Isotropic scaling keeps `camera_cond`'s resolution-normalised intrinsics exactly valid with no propagation work; the cost is that unifying to a common patch grid is the model's job. **A consumer assuming a uniform grid will break.** An anisotropic resize here would fail *silently* while invalidating the conditioning vector, which is why the loader's docstring says so explicitly.

**Real calibration now loads.** The sidecar carries EEPROM-read intrinsics for all three OAK-D cameras. Two assumptions in the original contract turned out wrong and are corrected here: the lenses are **`opencv` with 14 distortion coefficients, not fisheye**, and the schema's `extra="forbid"` rejected the provenance fields outright, so a genuine calibration file would not load at all. `mxid`, `socket`, `rotated_180` and `intrinsics_source` are now optional fields.

`rotated_180` is a **marker, not an instruction**: the recorder rotates every camera 180°, EEPROM describes the unrotated sensor, so `cx,cy` are flipped to `(W-1-cx, H-1-cy)` and the tangential/thin-prism/tilt distortion terms negated *before* they reach the file. Nothing downstream re-applies it.

With real values in place, `cond()` returns a `(3, 13)` matrix that **varies across cameras** instead of being constant. Nine of those dims are still identity until extrinsic calibration lands, so `placeholder` stays `true` and the loader still warns.

## Action is a derived signal — read this before using it

There is **no commanded/target topic anywhere in the source MCAP**; every topic is a measurement. So `action.future_state` is defined by the standard glove-teleop convention — **action(t) = the chunk of future states `[t+1 … t+H]`**, H=6, in the same parameterisation as the state. That is a decision, not something read off the data.

`action.commanded` is reserved as a first-class slot, currently a byte-identical alias. When real teleop lands (see [nutron-cli#3](https://github.com/yaak-ai/nutron-cli/pull/3), which adds the commanded/measured/glove recording) it populates that slot and the alias is dropped, with no schema change.

Note it is currently ~199 MB of a ~470 MB TensorDict, scaling linearly — **prefer aliasing it model-side** over materialising both.

## Tests

**26 new tests**, covering alignment residual bounds, quaternion canonicalisation, the missing-side mask, per-camera `frame_index` joins, goal extraction, and non-uniform episode lengths.

Baseline on `main` was 15 passed / 11 errors, with `tests/test_io.py` uncollectable — the private `idl-repo` submodule can't be cloned, so the yaak protobuf stubs don't exist. The yaak imports in `conftest.py`/`test_io.py` are now guarded, mirroring what `rbyte.io.__init__` already does, which makes the suite collectable. After: **42 passed, 7 skipped, 5 errors** — the same pre-existing pytest fixture-finalizer cascade from the unavailable yaak fixture. **Zero failures introduced.**

## Things a reviewer might otherwise assume

- **Don't trust `.rbyte_cache` sample counts.** A stale cache previously mis-sized an LR schedule by 25× in rmind. This config sets no `run_folder`, so caching is off on this path entirely; the 15,047 figure comes from three agreeing derivations.
- **Episode lengths are highly non-uniform** — 307 to 805 glove samples (~3.7 s to ~9.6 s). Don't estimate dataset size by multiplying an average.
- `${data_dir}` is a variable, never hardcoded: the same share is `/nasa/drives/...` on Linux and `/Volumes/data/drives/...` on macOS.
- Running the config needs `--extra nero --extra video`; a missing extra surfaces as hydra's confusing "Error locating target".
- Windowing is dense (`every: 1i`); non-overlapping would give ~2.5k samples instead of 15k.
- **`T` is a shared parameter.** Ingestion windows with `T=6`; the driving configs inherited from rmind#265 use `clip_length=11`. Both are self-consistent, but the policy's history length must match what was actually windowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
