### PR TITLE
feat: nero-arms depth (disparity) ingestion

### DIFF
--- a/config/_templates/dataset/nero_arms.yaml
+++ b/config/_templates/dataset/nero_arms.yaml
@@ -129,6 +129,30 @@
 #@ clip_length = 6
 #@ # §6.2: action == the chunk of future states [t+1 .. t+H].
 #@ action_horizon = 6
+
+#@ # §21 depth stream, OFF by default: no recording carries `base_disparity.mkv`
+#@ # yet. The mono intrinsics ARE now measured (§21.5: fx_mono 576.37 px @
+#@ # 1280x800, baseline 75.00 mm, MinZ 0.455 m), so `depth: true` works as soon
+#@ # as the recorder writes the stream -- provided `${data_dir}/calibration.yaml`
+#@ # carries the matching `stereo:` block; without it the depth streams fail
+#@ # loudly rather than emitting mis-scaled metres. `depth_output` may be set to
+#@ # "disparity" to ingest raw uint8 levels with no calibration at all. Flipping
+#@ # `depth` rewires the stream keys, the meta PipeFunc, the semi-join and the
+#@ # cast together -- never half of them.
+#@ depth = False
+#@ depth_output = "depth"          #! "depth" (metres) | "disparity" (uint8 levels)
+#@ depth_camera = "base"           #! §21.3: the overhead camera only
+#@ depth_file = depth_camera + "_disparity.mkv"
+#@ depth_index = "frame_index.disparity." + depth_camera
+
+#@ meta_names = [c + "_meta" for c in cameras]
+#@ if depth:
+#@   meta_names = meta_names + ["disparity_meta"]
+#@ end
+#@ meta_args = ", ".join(meta_names)
+#@ meta_mapspec = ", ".join([n + "[i]" for n in meta_names])
+#@ depth_join = 'SEMI JOIN disparity_meta ON nero."' + depth_index + '" = disparity_meta.frame_idx' if depth else ""
+#@ depth_cast = '"' + depth_index + '"::INT32[' + str(clip_length) + '] AS "' + depth_index + '",' if depth else ""
 ---
 _target_: rbyte.Dataset.from_config
 _recursive_: false
@@ -158,6 +182,32 @@ streams:
           - _target_: torchcodec.transforms.Resize
             size: #@ size
 
+  #@ if depth:
+  #@ # §21.4: joined on its **own** `frame_index`, never resized -- a resize
+  #@ # scales `fx` but not the stored disparity levels. Depth and its validity
+  #@ # mask are two streams over one file because an rbyte stream is one tensor;
+  #@ # `disparity == 0` is INVALID, not 0 m, so `depth.*` is unusable alone.
+  (@=depth_output@).(@=depth_camera@):
+    index: (@=depth_index@)
+    sources:
+      #@ for/end episode in episodes:
+      (@=episode@):
+        _target_: rbyte.io.NeroArmsDisparityFrameSource
+        source: ${data_dir}/(@=episode@)/(@=depth_file@)
+        output: (@=depth_output@)
+        camera: (@=depth_camera@)
+        calibration_path: ${data_dir}/calibration.yaml
+
+  depth_valid.(@=depth_camera@):
+    index: (@=depth_index@)
+    sources:
+      #@ for/end episode in episodes:
+      (@=episode@):
+        _target_: rbyte.io.NeroArmsDisparityFrameSource
+        source: ${data_dir}/(@=episode@)/(@=depth_file@)
+        output: valid
+  #@ end
+
 samples:
   inputs:
     input_id:
@@ -176,6 +226,12 @@ samples:
     (@=camera@)_path:
       #@ for/end episode in episodes:
       - ${data_dir}/(@=episode@)/(@=camera@).mp4
+
+    #@ if depth:
+    disparity_path:
+      #@ for/end episode in episodes:
+      - ${data_dir}/(@=episode@)/(@=depth_file@)
+    #@ end
 
   executor:
     _target_: concurrent.futures.ProcessPoolExecutor
@@ -205,6 +261,12 @@ samples:
             #@ for/end camera in cameras:
             - (@=camera@)
           reference_camera: (@=list(cameras)[0]@)
+          #! §21: adds `frame_index.disparity.{camera}` and asserts the episode's
+          #! declared stereo mode (`subpixel` must be false).
+          disparity_cameras:
+            #@ if depth:
+            - (@=depth_camera@)
+            #@ end
 
       #@ for/end camera in cameras:
       - _target_: pipefunc.PipeFunc
@@ -218,14 +280,27 @@ samples:
             frame_idx:
               _target_: polars.Int32
 
+      #@ if depth:
+      - _target_: pipefunc.PipeFunc
+        renames:
+          path: disparity_path
+        output_name: disparity_meta
+        mapspec: "${.renames.path}[i] -> ${.output_name}[i]"
+        func:
+          _target_: rbyte.io.VideoDataFrameBuilder
+          fields:
+            frame_idx:
+              _target_: polars.Int32
+      #@ end
+
       #@ # §3: each camera is joined on its own `frame_index`; the semi-joins drop
       #@ # any row whose frame is missing from the corresponding mp4.
       - _target_: pipefunc.PipeFunc
         output_name: filtered
-        mapspec: "nero[i], base_meta[i], side_left_meta[i], side_right_meta[i] -> ${.output_name}[i]"
+        mapspec: "nero[i], (@=meta_mapspec@) -> ${.output_name}[i]"
         func:
           _target_: makefun.create_function
-          func_signature: "filter(*, nero, base_meta, side_left_meta, side_right_meta)"
+          func_signature: "filter(*, nero, (@=meta_args@))"
           func_impl:
             _target_: rbyte.io.DuckDBDataFrameQuery
             query: |
@@ -238,6 +313,7 @@ samples:
                   ON nero."frame_index.side_left" = side_left_meta.frame_idx
                 SEMI JOIN side_right_meta
                   ON nero."frame_index.side_right" = side_right_meta.frame_idx
+                (@=depth_join@)
               WHERE
                 COLUMNS(*) IS NOT NULL
               ORDER BY
@@ -266,7 +342,8 @@ samples:
           func_impl:
             _target_: rbyte.io.DuckDBDataFrameQuery
             query: |
-              SELECT "frame_index.base"::INT32[(@=str(clip_length)@)] AS "frame_index.base",
+              SELECT (@=depth_cast@)
+                     "frame_index.base"::INT32[(@=str(clip_length)@)] AS "frame_index.base",
                      "frame_index.side_left"::INT32[(@=str(clip_length)@)] AS "frame_index.side_left",
                      "frame_index.side_right"::INT32[(@=str(clip_length)@)] AS "frame_index.side_right",
                      "state.pose"::FLOAT[46][2][(@=str(clip_length)@)] AS "state.pose",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ check = [
 ]
 test = [
   "dill>=0.4.1",
+  "imageio-ffmpeg>=0.6.0",
   "pytest>=9.0.2",
   "pytest-lazy-fixtures>=1.4.0",
   "testbook>=0.4.2",

--- a/src/rbyte/io/__init__.py
+++ b/src/rbyte/io/__init__.py
@@ -47,11 +47,18 @@ else:
     ]
 
 try:  # noqa: RUF067
-    from .nero import NeroArmsCalibration, NeroArmsDataFrameBuilder
+    from .nero import NeroArmsCalibration, NeroArmsDataFrameBuilder, StereoCalibration
 except ImportError:
     pass
 else:
-    __all__ += ["NeroArmsCalibration", "NeroArmsDataFrameBuilder"]
+    __all__ += ["NeroArmsCalibration", "NeroArmsDataFrameBuilder", "StereoCalibration"]
+
+    try:  # needs the `video` extra as well
+        from .nero import NeroArmsDisparityFrameSource
+    except (ImportError, RuntimeError):
+        pass
+    else:
+        __all__ += ["NeroArmsDisparityFrameSource"]
 
 try:  # noqa: RUF067
     from .video import TorchCodecFrameSource, VideoDataFrameBuilder

--- a/src/rbyte/io/nero/__init__.py
+++ b/src/rbyte/io/nero/__init__.py
@@ -1,5 +1,18 @@
-from .calibration import CAMERA_COND_DIM, CameraModel, NeroArmsCalibration
+from .calibration import (
+    CAMERA_COND_DIM,
+    MAX_DISPARITY,
+    CameraModel,
+    NeroArmsCalibration,
+    StereoCalibration,
+)
 from .dataframe_builder import NeroArmsDataFrameBuilder
+from .disparity import (
+    DISPARITY_METADATA_PREFIX,
+    DISPARITY_TOPIC_PREFIX,
+    DisparityDeclaration,
+    DisparityOutput,
+    disparity_to_depth,
+)
 from .rotation import (
     canonicalize_quat,
     pose_9d_to_quat,
@@ -24,17 +37,24 @@ from .schema import (
 __all__ = [
     "CAMERAS",
     "CAMERA_COND_DIM",
+    "DISPARITY_METADATA_PREFIX",
+    "DISPARITY_TOPIC_PREFIX",
     "FINGERS",
     "IMU_DIM",
     "IMU_SEGMENTS",
+    "MAX_DISPARITY",
     "SIDES",
     "STATE_DIM_9D",
     "STATE_DIM_QUAT",
     "STATUS_SENSORS",
     "CameraModel",
+    "DisparityDeclaration",
+    "DisparityOutput",
     "NeroArmsCalibration",
     "NeroArmsDataFrameBuilder",
+    "StereoCalibration",
     "canonicalize_quat",
+    "disparity_to_depth",
     "pose_9d_to_quat",
     "pose_quat_to_9d",
     "quat_slerp",
@@ -43,3 +63,11 @@ __all__ = [
     "state_9d_to_quat",
     "state_quat_to_9d",
 ]
+
+# torchcodec (the `video` extra) is not required by the rest of `nero`.
+try:  # noqa: RUF067
+    from .disparity_source import NeroArmsDisparityFrameSource
+except (ImportError, RuntimeError):
+    pass
+else:
+    __all__ += ["NeroArmsDisparityFrameSource"]

--- a/src/rbyte/io/nero/calibration.py
+++ b/src/rbyte/io/nero/calibration.py
@@ -10,22 +10,73 @@ also emitted as a per-sample column so the assertion can be made on a batch.
 from collections.abc import Sequence
 from enum import StrEnum, auto, unique
 from pathlib import Path
-from typing import Annotated, Self, final
+from typing import Annotated, Final, Self, final
 
 import numpy as np
 import numpy.typing as npt
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, FilePath, validate_call
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    FilePath,
+    PositiveFloat,
+    PositiveInt,
+    model_validator,
+    validate_call,
+)
 from structlog import get_logger
 
 from rbyte.io.nero.rotation import matrix_to_quat, quat_to_rot6d
 
-__all__ = ["CAMERA_COND_DIM", "CameraModel", "NeroArmsCalibration"]
+__all__ = [
+    "CAMERA_COND_DIM",
+    "MAX_DISPARITY",
+    "CameraModel",
+    "NeroArmsCalibration",
+    "StereoCalibration",
+]
 
 logger = get_logger(__name__)
 
 #: §7.1: `fx/W, fy/H, cx/W, cy/H` + `t_world_cam` (3) + `R_world_cam` as 6D.
 CAMERA_COND_DIM = 13
+
+#: §21.1, keyed by `extended_disparity`. `subpixel` would make it 760, which does
+#: not fit in the 8 bits the stream is stored in -- hence the hard assertion.
+MAX_DISPARITY: Final[dict[bool, int]] = {False: 95, True: 191}
+
+
+def check_disparity_mode(
+    *, max_disparity: int, subpixel: bool, extended_disparity: bool, source: str
+) -> None:
+    """§21.1/§21.3: the declared stereo mode must be 8-bit representable.
+
+    `subpixel` multiplies disparity by 8 and needs 16 bits; reading such a stream
+    as uint8 is silently wrong by a factor of 8, so it is refused rather than
+    warned about. `max_disparity` is *declared*, never inferred (§17.1) -- but a
+    declaration that contradicts `extended_disparity` is a recorder bug, and
+    assuming 95 when 191 was recorded scales every depth by 2x.
+    """
+    if subpixel:
+        logger.error(
+            msg := "§21.1: `subpixel` must be false -- subpixel disparity needs "
+            "16 bits and an 8-bit read is silently wrong by a factor of 8",
+            source=source,
+        )
+
+        raise ValueError(msg)
+
+    if max_disparity != (expected := MAX_DISPARITY[extended_disparity]):
+        logger.error(
+            msg := "§21.1: declared `max_disparity` contradicts `extended_disparity`",
+            source=source,
+            max_disparity=max_disparity,
+            extended_disparity=extended_disparity,
+            expected=expected,
+        )
+
+        raise ValueError(msg)
 
 
 @unique
@@ -89,11 +140,76 @@ class CameraCalibration(BaseModel):
         ]).astype(np.float32)
 
 
+class StereoCalibration(BaseModel):
+    """§21: the **mono pair** behind a disparity stream.
+
+    `fx_mono` is the mono (`CAM_B`/`CAM_C`) focal length, **not** the `fx` under
+    `cameras:` -- that one is `CAM_A`, the RGB camera, a different and much
+    narrower lens (§21.5). Using it would scale every depth wrong, and did:
+    an earlier MinZ of ~0.70 m came from plugging the RGB `fx` into the formula.
+
+    `image_size` is the resolution `fx_mono` is expressed at, and the disparity
+    frames MUST be decoded at exactly that size: a resize scales `fx` but *not*
+    the stored disparity values, so `fx * baseline / disparity` would come out
+    wrong by the resize factor. The depth stream is therefore never resized.
+    """
+
+    fx_mono: PositiveFloat
+    """px, at `image_size`. `c.getCameraIntrinsics(CAM_B, resizeWidth=W, ...)`."""
+    baseline_m: PositiveFloat
+    """m. `c.getBaselineDistance()` returns cm."""
+    image_size: tuple[PositiveInt, PositiveInt]
+    """`(width, height)` of the disparity frames."""
+
+    # §21.3 / §17.1: declared, never inferred.
+    max_disparity: PositiveInt
+    subpixel: bool = False
+    extended_disparity: bool = False
+    mono_sockets: tuple[str, str] | None = None
+
+    placeholder: bool = True
+    """A guessed block is worse than none: it scales every depth silently, so
+    `NeroArmsCalibration.stereo_for` refuses to use one. The `base` OAK-D W
+    values are MEASURED off the device; a second rig starts out placeholder."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    @property
+    def min_depth_m(self) -> float:
+        """Closest resolvable distance -- depth at `max_disparity`.
+
+        Measured `base` rig (`fx_mono` 576.37 px @ 1280x800, baseline 75.00 mm):
+        **0.455 m** in the default mode, **0.226 m** with extended disparity.
+        `CAMERA_RIG.md` §4.2: check this against the actual mount height, since
+        an overhead camera sitting inside its own minimum range is unusable.
+        """
+        return self.fx_mono * self.baseline_m / self.max_disparity
+
+    @property
+    def max_depth_m(self) -> float:
+        """Depth at disparity 1, the coarsest non-invalid level (43.2 m here)."""
+        return self.fx_mono * self.baseline_m
+
+    @model_validator(mode="after")
+    def _check_mode(self) -> Self:
+        check_disparity_mode(
+            max_disparity=self.max_disparity,
+            subpixel=self.subpixel,
+            extended_disparity=self.extended_disparity,
+            source="calibration.stereo",
+        )
+
+        return self
+
+
 @final
 class NeroArmsCalibration(BaseModel):
     version: int
     world_frame: str
     cameras: dict[str, CameraCalibration]
+    stereo: dict[str, StereoCalibration] = {}
+    """§21, keyed by camera name like `cameras`. Carries the MONO pair, which
+    `cameras` does not; raw disparity ingests fine without it."""
     placeholder: bool = True
 
     intrinsics_source: str | None = None
@@ -117,6 +233,41 @@ class NeroArmsCalibration(BaseModel):
             )
 
         return calibration
+
+    def stereo_for(self, camera: str) -> StereoCalibration:
+        """§21.4: the mono pair for `camera`, or a loud failure.
+
+        Emitting raw disparity does not need this; metric depth does, and there
+        is no safe default -- a missing or placeholder block would silently scale
+        every depth reading, so it is refused.
+        """
+        match self.stereo.get(camera):
+            case None:
+                logger.error(
+                    msg := "§21.4: no `stereo` calibration for camera -- metric "
+                    "depth needs the MONO pair's `fx_mono` and `baseline_m`, "
+                    "which are NOT the `cameras` intrinsics (those are the RGB "
+                    "CAM_A). Measure them, or ingest raw disparity instead.",
+                    camera=camera,
+                    available=sorted(self.stereo),
+                )
+
+                raise ValueError(msg)
+
+            case stereo if stereo.placeholder:
+                logger.error(
+                    msg := "§21.4: `stereo` calibration is still PLACEHOLDER -- "
+                    "metric depth would be silently wrong by whatever the "
+                    "guessed `fx_mono`/`baseline_m` are off by",
+                    camera=camera,
+                    fx_mono=stereo.fx_mono,
+                    baseline_m=stereo.baseline_m,
+                )
+
+                raise ValueError(msg)
+
+            case stereo:
+                return stereo
 
     def cond(self, cameras: Sequence[str]) -> npt.NDArray[np.float32]:
         """§7.1 conditioning matrix, `(len(cameras), 13)` float32."""

--- a/src/rbyte/io/nero/dataframe_builder.py
+++ b/src/rbyte/io/nero/dataframe_builder.py
@@ -16,6 +16,11 @@ from structlog import get_logger
 from structlog.contextvars import bound_contextvars
 
 from rbyte.io.nero.calibration import NeroArmsCalibration
+from rbyte.io.nero.disparity import (
+    DISPARITY_METADATA_PREFIX,
+    DISPARITY_TOPIC_PREFIX,
+    DisparityDeclaration,
+)
 from rbyte.io.nero.rotation import canonicalize_quat, quat_slerp, quat_to_matrix
 from rbyte.io.nero.schema import (
     CAMERAS,
@@ -94,6 +99,8 @@ class _Stream(NamedTuple):
 
 
 class _Camera(NamedTuple):
+    """Any `ImageFrameIndex` stream -- an mp4 camera or the disparity mkv."""
+
     frame_index: npt.NDArray[np.int32]
     stream: _Stream
 
@@ -147,6 +154,7 @@ class NeroArmsDataFrameBuilder:
     | column                        | dtype                        |
     |-------------------------------|------------------------------|
     | `frame_index.{camera}`        | `Int32`                      |
+    | `frame_index.disparity.{cam}` | `Int32`                      |
     | `state.pose`                  | `Array(Float32, (2, 46))`    |
     | `state.pose_rel_start`        | `Array(Float32, (2, 46))`    |
     | `action.future_state`         | `Array(Float32, (H, 2, 46))` |
@@ -165,6 +173,11 @@ class NeroArmsDataFrameBuilder:
 
     The last `action_horizon` rows of every episode are dropped: they have no
     full future chunk, and clamping or wrapping the chunk would fabricate data.
+
+    `disparity_cameras` (§21, empty by default) adds the depth stream's own
+    index columns and asserts the episode's declared stereo mode -- `subpixel`
+    false above all. The pixels themselves are decoded by
+    `rbyte.io.NeroArmsDisparityFrameSource`.
     """
 
     __name__ = __qualname__
@@ -182,6 +195,7 @@ class NeroArmsDataFrameBuilder:
         offset_percentile: NonNegativeFloat = 0.0,
         include_imu: bool = False,
         include_status_flags: bool = False,
+        disparity_cameras: Sequence[str] = (),
     ) -> None:
         if reference_camera not in cameras:
             logger.error(msg := "`reference_camera` not in `cameras`")
@@ -191,6 +205,7 @@ class NeroArmsDataFrameBuilder:
         self._cameras = tuple(cameras)
         self._reference_camera = reference_camera
         self._sides = tuple(sides)
+        self._disparity_cameras = tuple(disparity_cameras)
         self._action_horizon = action_horizon
         self._align_tolerance_ms = align_tolerance_ms
         self._camera_gap_tolerance_ms = camera_gap_tolerance_ms
@@ -223,11 +238,23 @@ class NeroArmsDataFrameBuilder:
         )
 
     @property
+    def _index_topics(self) -> dict[str, str]:
+        """Column key -> `ImageFrameIndex` topic, reference camera first.
+
+        §3/§21.4: every one of these is joined on **its own** `frame_index` --
+        the disparity stream may have a different frame count from the mp4s just
+        as the mp4s differ from each other.
+        """
+        return {
+            camera: f"{_IMAGE_TOPIC_PREFIX}{camera}" for camera in self._cameras
+        } | {
+            f"disparity.{camera}": f"{DISPARITY_TOPIC_PREFIX}{camera}"
+            for camera in self._disparity_cameras
+        }
+
+    @property
     def _topics(self) -> tuple[str, ...]:
-        topics = [
-            _TIMING_TOPIC,
-            *(f"{_IMAGE_TOPIC_PREFIX}{camera}" for camera in self._cameras),
-        ]
+        topics = [_TIMING_TOPIC, *self._index_topics.values()]
         for side in self._sides:
             topics += self._side_topics(side)
             if self._include_imu:
@@ -245,11 +272,20 @@ class NeroArmsDataFrameBuilder:
 
     # -------------------------------------------------------------------- read
 
-    def _read(self, path: Path) -> tuple[_Floats, _Ints]:
+    def _read(self, path: Path) -> tuple[_Floats, _Ints, dict[str, dict[str, str]]]:
         floats: _Floats = defaultdict(list)
         ints: _Ints = defaultdict(list)
+        metadata: dict[str, dict[str, str]] = {}
 
         with path.open("rb") as f:
+            reader = make_reader(f, decoder_factories=[DecoderFactory()])
+            # §17.1: per-episode declarations. Presence is declared, never
+            # inferred from topic absence.
+            metadata = {
+                record.name: record.metadata for record in reader.iter_metadata()
+            }
+
+            f.seek(0)
             reader = make_reader(f, decoder_factories=[DecoderFactory()])
             for _schema, channel, _message, decoded in reader.iter_decoded_messages(
                 topics=self._topics
@@ -294,7 +330,38 @@ class NeroArmsDataFrameBuilder:
                             decoded.host_arrival_time_ns,
                         ])
 
-        return floats, ints
+        return floats, ints, metadata
+
+    def _disparity_declarations(
+        self, metadata: dict[str, dict[str, str]], calibration: NeroArmsCalibration
+    ) -> dict[str, DisparityDeclaration]:
+        """§21.3/§21.4: the declared stereo mode, asserted, never inferred.
+
+        A missing record when disparity ingestion is switched on is a hard
+        failure -- falling back to the calibration block would be exactly the
+        §17.1 mistake of inferring presence from absence.
+        """
+        declarations: dict[str, DisparityDeclaration] = {}
+        for camera in self._disparity_cameras:
+            name = f"{DISPARITY_METADATA_PREFIX}{camera}"
+            if (record := metadata.get(name)) is None:
+                logger.error(
+                    msg := "§21.3: episode metadata does not declare the "
+                    "disparity stream; `max_disparity`/`subpixel`/"
+                    "`extended_disparity` must be declared, never inferred",
+                    record=name,
+                    available=sorted(metadata),
+                )
+
+                raise ValueError(msg)
+
+            declaration = DisparityDeclaration.from_mcap_metadata(record)
+            if (stereo := calibration.stereo.get(camera)) is not None:
+                declaration.check_against(stereo, camera=camera)
+
+            declarations[camera] = declaration
+
+        return declarations
 
     # ---------------------------------------------------------------- timebase
 
@@ -311,7 +378,10 @@ class NeroArmsDataFrameBuilder:
         # are published one-per-`timing.rgmp` sample, so the join is ordinal --
         # a single length mismatch would silently shift every pose.
         for topic, values in (*floats.items(), *ints.items()):
-            if topic.startswith(_IMAGE_TOPIC_PREFIX) or topic == _TIMING_TOPIC:
+            if (
+                topic.startswith((_IMAGE_TOPIC_PREFIX, DISPARITY_TOPIC_PREFIX))
+                or topic == _TIMING_TOPIC
+            ):
                 continue
 
             if len(values) != len(glove.device_ns):
@@ -328,8 +398,7 @@ class NeroArmsDataFrameBuilder:
 
     def _cameras_from(self, ints: _Ints) -> dict[str, _Camera]:
         cameras: dict[str, _Camera] = {}
-        for camera in self._cameras:
-            topic = f"{_IMAGE_TOPIC_PREFIX}{camera}"
+        for camera, topic in self._index_topics.items():
             if topic not in ints:
                 logger.error(msg := "missing camera topic", topic=topic)
 
@@ -487,7 +556,12 @@ class NeroArmsDataFrameBuilder:
     def _frame_index_columns(
         self, cameras: dict[str, _Camera], r: _Resampling, n: int
     ) -> dict[str, pl.Series]:
-        """Join every camera on its own `frame_index` (§3, dropped frames)."""
+        """Join every indexed stream on its own `frame_index` (§3, §21.4).
+
+        Covers the mp4 cameras and the disparity mkv identically -- the latter is
+        keyed `disparity.{camera}` and is not assumed to share a frame count with
+        anything.
+        """
         grid_ns = r.grid_ns[:n]
         columns: dict[str, pl.Series] = {}
         for camera, (frame_index, stream) in cameras.items():
@@ -522,9 +596,19 @@ class NeroArmsDataFrameBuilder:
 
     # ------------------------------------------------------------------- build
 
-    def _build(self, path: Path, calibration_path: Path) -> pl.DataFrame:
+    def _build(self, path: Path, calibration_path: Path) -> pl.DataFrame:  # noqa: PLR0914
         calibration = NeroArmsCalibration.from_path(calibration_path)
-        floats, ints = self._read(path)
+        floats, ints, metadata = self._read(path)
+        declarations = self._disparity_declarations(metadata, calibration)
+        if declarations:
+            logger.debug(
+                "disparity streams declared",
+                declarations={
+                    camera: declaration.model_dump(exclude_none=True)
+                    for camera, declaration in declarations.items()
+                },
+            )
+
         glove = self._glove(floats, ints)
         cameras = self._cameras_from(ints)
         resampling = self._resample(glove, cameras[self._reference_camera])

--- a/src/rbyte/io/nero/disparity.py
+++ b/src/rbyte/io/nero/disparity.py
@@ -1,0 +1,159 @@
+"""nero-arms depth stream: 8-bit disparity -> metric depth (data contract §21).
+
+The recorder writes **disparity**, not depth, as 8-bit `gray` FFV1 in MKV
+(`base_disparity.mkv`), overhead camera only. §21.1: disparity is exactly
+representable in 8 bits as long as `subpixel` is off, which halves the data
+before any codec runs and defers the metric conversion to here, where the
+calibration lives.
+
+This module is the calibration/declaration half and deliberately does **not**
+import torchcodec, so `rbyte.io.nero` stays importable without the `video`
+extra. The decoder lives in `disparity_source.py`.
+"""
+
+from enum import StrEnum, auto, unique
+from typing import Final, Self
+
+import torch
+from pydantic import BaseModel, ConfigDict, PositiveInt, model_validator
+from structlog import get_logger
+from torch import Tensor
+
+from rbyte.io.nero.calibration import StereoCalibration, check_disparity_mode
+
+__all__ = [
+    "DISPARITY_METADATA_PREFIX",
+    "DISPARITY_TOPIC_PREFIX",
+    "LOSSLESS_CODECS",
+    "PIXEL_FORMAT",
+    "DisparityDeclaration",
+    "DisparityOutput",
+    "disparity_to_depth",
+]
+
+logger = get_logger(__name__)
+
+#: §21.3: same `ImageFrameIndex` schema as the cameras, own `frame_index`.
+DISPARITY_TOPIC_PREFIX: Final = "observation.disparity."
+#: §21.3 episode metadata record, alongside the existing `camera.{name}` ones.
+DISPARITY_METADATA_PREFIX: Final = "disparity."
+
+#: §21.2: the only pixel format that survives torchcodec bit-exactly.
+PIXEL_FORMAT: Final = "gray"
+#: §21.2: never a lossy codec.
+LOSSLESS_CODECS: Final = frozenset({"ffv1"})
+
+
+@unique
+class DisparityOutput(StrEnum):
+    """What a `NeroArmsDisparityFrameSource` emits per frame."""
+
+    #: raw uint8 disparity levels; needs no calibration
+    disparity = auto()
+    #: float32 metres, 0.0 where invalid -- see `valid`
+    depth = auto()
+    #: bool, False where `disparity == 0` (§21.4: invalid, not zero distance)
+    valid = auto()
+
+
+class DisparityDeclaration(BaseModel):
+    """§21.3 episode metadata for the disparity stream.
+
+    Per §17.1 these are **declared**, never inferred from the pixels: a consumer
+    that assumes 95 when extended disparity was on computes every depth wrong by
+    2x, and there is nothing in the frames that says which was used.
+    """
+
+    max_disparity: PositiveInt
+    subpixel: bool
+    extended_disparity: bool
+    width: PositiveInt | None = None
+    height: PositiveInt | None = None
+    mono_sockets: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+    @model_validator(mode="after")
+    def _check_mode(self) -> Self:
+        check_disparity_mode(
+            max_disparity=self.max_disparity,
+            subpixel=self.subpixel,
+            extended_disparity=self.extended_disparity,
+            source="episode metadata",
+        )
+
+        return self
+
+    @classmethod
+    def from_mcap_metadata(cls, metadata: dict[str, str]) -> Self:
+        """MCAP metadata records are `dict[str, str]`; booleans arrive as text."""
+
+        def parse(value: str) -> bool:
+            match value.strip().lower():
+                case "true" | "1" | "yes":
+                    return True
+
+                case "false" | "0" | "no":
+                    return False
+
+                case _:
+                    logger.error(
+                        msg := "§21.3: undecodable boolean in episode metadata",
+                        value=value,
+                    )
+
+                    raise ValueError(msg)
+
+        return cls.model_validate(
+            metadata
+            | {
+                key: parse(metadata[key])
+                for key in ("subpixel", "extended_disparity")
+                if key in metadata
+            }
+        )
+
+    def check_against(self, stereo: StereoCalibration, *, camera: str) -> None:
+        """The per-episode declaration wins; a disagreement is a hard failure."""
+        mismatched = {
+            field: (declared, calibrated)
+            for field in ("max_disparity", "subpixel", "extended_disparity")
+            if (declared := getattr(self, field))
+            != (calibrated := getattr(stereo, field))
+        }
+        if self.width is not None and self.height is not None:
+            size = (self.width, self.height)
+            if size != stereo.image_size:
+                mismatched["image_size"] = (size, stereo.image_size)
+
+        if mismatched:
+            logger.error(
+                msg := "§21.3: episode metadata disagrees with `stereo` calibration",
+                camera=camera,
+                mismatched=mismatched,
+            )
+
+            raise ValueError(msg)
+
+
+def disparity_to_depth(
+    disparity: Tensor, stereo: StereoCalibration
+) -> tuple[Tensor, Tensor]:
+    """§21.4: `(depth_m, valid)` from uint8 disparity levels.
+
+    `depth_m = fx_mono_px * baseline_m / disparity`, with `disparity == 0`
+    meaning **invalid, not zero distance**. The denominator is clamped *before*
+    the division, so an invalid pixel can never produce `inf` (which would turn
+    into `nan` the moment anything multiplies it by the mask) and never becomes a
+    0 m reading either -- it is 0.0 *and* masked out, and consumers must use the
+    mask.
+    """
+    valid = disparity > 0
+    safe = disparity.to(torch.float32).clamp(min=1.0)
+    depth = torch.where(
+        valid,
+        stereo.fx_mono * stereo.baseline_m / safe,
+        torch.zeros((), dtype=safe.dtype),
+    )
+
+    return depth, valid

--- a/src/rbyte/io/nero/disparity_source.py
+++ b/src/rbyte/io/nero/disparity_source.py
@@ -74,6 +74,7 @@ class NeroArmsDisparityFrameSource(TensorSource[int]):
             seek_mode="exact",
         )
         self._check_decodable(str(source))
+        self._check_channels()
         self._stereo = (
             None
             if output is not DisparityOutput.depth
@@ -105,6 +106,24 @@ class NeroArmsDisparityFrameSource(TensorSource[int]):
                 source=source,
                 pixel_format=pixel_format,
                 expected=PIXEL_FORMAT,
+            )
+
+            raise ValueError(msg)
+
+    def _check_channels(self) -> None:
+        """torchcodec hands `gray` back NCHW with the plane replicated across
+        three channels. Assert that once, here, rather than on every decode: at
+        the measured 1280x800 an all-close over a clip is tens of MB of pointless
+        traffic per sample, and the behaviour is fixed for a given file.
+        """
+        if not self._decoder.metadata.num_frames:
+            return
+
+        frames = self._decoder.get_frame_at(index=0).data
+        if frames.shape[-3] != 1 and not bool((frames == frames[..., :1, :, :]).all()):
+            logger.error(
+                msg := "disparity frames are not single-channel gray",
+                shape=tuple(frames.shape),
             )
 
             raise ValueError(msg)
@@ -162,20 +181,8 @@ class NeroArmsDisparityFrameSource(TensorSource[int]):
             case int():
                 frames = self._decoder.get_frame_at(index=indexes).data.unsqueeze(0)
 
-        # torchcodec hands back NCHW with a `gray` plane replicated across three
-        # channels. Assert the replication rather than assuming it, then keep one.
-        if frames.shape[-3] != 1:
-            if not bool((frames == frames[..., :1, :, :]).all()):
-                logger.error(
-                    msg := "disparity frames are not single-channel gray",
-                    shape=tuple(frames.shape),
-                )
-
-                raise ValueError(msg)
-
-            frames = frames[..., :1, :, :]
-
-        out = frames.contiguous()
+        # replication across the three channels is checked once, in `__init__`
+        out = frames[..., :1, :, :].contiguous()
 
         return out if isinstance(indexes, Sequence) else out.squeeze(0)
 

--- a/src/rbyte/io/nero/disparity_source.py
+++ b/src/rbyte/io/nero/disparity_source.py
@@ -1,0 +1,200 @@
+"""torchcodec decoding for the nero-arms disparity stream (data contract §21).
+
+Two measured findings shape this module (§21.2):
+
+1. FFV1 8-bit `gray` is **bit-exact** through torchcodec, which rbyte already
+   uses for the mp4s -- so the depth stream reuses the `ImageFrameIndex` +
+   `frame_index` machinery with no new decoder.
+2. ⚠️ torchcodec **silently down-converts 16-bit video to uint8**. It does not
+   raise; it returns plausible-looking wrong data (measured max error 58751).
+   `_check_decodable` therefore refuses anything that is not 8-bit `gray`, and
+   points at PyAV, which decodes 16-bit bit-exactly.
+
+A lossy codec is refused for the same reason: libx264 on 8-bit disparity gave a
+max error of 81 levels at 95 levels full scale.
+"""
+
+from collections.abc import Sequence
+from typing import final, override
+
+from pydantic import FilePath, InstanceOf, validate_call
+from structlog import get_logger
+from torch import Tensor
+from torchcodec.decoders import VideoDecoder
+
+from rbyte.io.nero.calibration import NeroArmsCalibration, StereoCalibration
+from rbyte.io.nero.disparity import (
+    LOSSLESS_CODECS,
+    PIXEL_FORMAT,
+    DisparityOutput,
+    disparity_to_depth,
+)
+from rbyte.types import TensorSource
+
+__all__ = ["NeroArmsDisparityFrameSource"]
+
+logger = get_logger(__name__)
+
+
+@final
+class NeroArmsDisparityFrameSource(TensorSource[int]):
+    """Decode `{camera}_disparity.mkv` and optionally convert it to metric depth.
+
+    One source == one output (`disparity` / `depth` / `valid`), because an rbyte
+    stream is a single tensor. A depth-plus-mask config declares two streams over
+    the same file.
+
+    Deliberately exposes **no** transforms: resizing a disparity map scales
+    `fx` but not the stored disparity values, so `fx * baseline / disparity`
+    would come out wrong by the resize factor (see `StereoCalibration`).
+    """
+
+    @validate_call
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        source: FilePath | str,
+        output: DisparityOutput = DisparityOutput.disparity,
+        camera: str | None = None,
+        calibration_path: FilePath | None = None,
+        stereo: InstanceOf[StereoCalibration] | None = None,
+        stream_index: int | None = None,
+        num_ffmpeg_threads: int = 1,
+        device: str | None = None,
+    ) -> None:
+        super().__init__()
+
+        self._output = output
+        self._decoder = VideoDecoder(
+            source=source,
+            stream_index=stream_index,
+            dimension_order="NCHW",
+            num_ffmpeg_threads=num_ffmpeg_threads,
+            device=device,
+            seek_mode="exact",
+        )
+        self._check_decodable(str(source))
+        self._stereo = (
+            None
+            if output is not DisparityOutput.depth
+            else self._resolve_stereo(camera, calibration_path, stereo)
+        )
+
+    # -------------------------------------------------------------- validation
+
+    def _check_decodable(self, source: str) -> None:
+        metadata = self._decoder.metadata
+        if (codec := metadata.codec) not in LOSSLESS_CODECS:
+            logger.error(
+                msg := "§21.2: disparity stream is not losslessly coded. A lossy "
+                "codec is destruction, not degradation -- libx264 on 8-bit "
+                "disparity measured a max error of 81 levels at 95 full scale.",
+                source=source,
+                codec=codec,
+                expected=sorted(LOSSLESS_CODECS),
+            )
+
+            raise ValueError(msg)
+
+        if (pixel_format := metadata.pixel_format) != PIXEL_FORMAT:
+            logger.error(
+                msg := "§21.2: disparity stream is not 8-bit gray. torchcodec "
+                "SILENTLY down-converts 16-bit video to uint8 -- it does not "
+                "raise, it returns wrong data. Decode this with PyAV instead, "
+                "and check whether `subpixel` was left on.",
+                source=source,
+                pixel_format=pixel_format,
+                expected=PIXEL_FORMAT,
+            )
+
+            raise ValueError(msg)
+
+    def _resolve_stereo(
+        self,
+        camera: str | None,
+        calibration_path: FilePath | None,
+        stereo: StereoCalibration | None,
+    ) -> StereoCalibration:
+        if stereo is None:
+            if calibration_path is None:
+                logger.error(
+                    msg := "§21.4: metric depth needs `stereo` or "
+                    "`calibration_path`; pass `output=disparity` to ingest raw "
+                    "disparity without calibration"
+                )
+
+                raise ValueError(msg)
+
+            if camera is None:
+                logger.error(msg := "`camera` is required with `calibration_path`")
+
+                raise ValueError(msg)
+
+            stereo = NeroArmsCalibration.from_path(calibration_path).stereo_for(camera)
+
+        elif stereo.placeholder:
+            logger.error(msg := "§21.4: `stereo` calibration is still PLACEHOLDER")
+
+            raise ValueError(msg)
+
+        metadata = self._decoder.metadata
+        if (size := (metadata.width, metadata.height)) != stereo.image_size:
+            logger.error(
+                msg := "disparity frame size != `stereo.image_size`; `fx_mono` "
+                "describes a different resolution, so every depth would be "
+                "scaled wrong",
+                size=size,
+                image_size=stereo.image_size,
+            )
+
+            raise ValueError(msg)
+
+        return stereo
+
+    # ------------------------------------------------------------------ decode
+
+    def _disparity(self, indexes: int | Sequence[int]) -> Tensor:
+        """uint8 `(N, 1, H, W)` disparity levels, bit-exact (§21.2)."""
+        match indexes:
+            case Sequence():
+                frames = self._decoder.get_frames_at(indices=list(indexes)).data
+
+            case int():
+                frames = self._decoder.get_frame_at(index=indexes).data.unsqueeze(0)
+
+        # torchcodec hands back NCHW with a `gray` plane replicated across three
+        # channels. Assert the replication rather than assuming it, then keep one.
+        if frames.shape[-3] != 1:
+            if not bool((frames == frames[..., :1, :, :]).all()):
+                logger.error(
+                    msg := "disparity frames are not single-channel gray",
+                    shape=tuple(frames.shape),
+                )
+
+                raise ValueError(msg)
+
+            frames = frames[..., :1, :, :]
+
+        out = frames.contiguous()
+
+        return out if isinstance(indexes, Sequence) else out.squeeze(0)
+
+    @override
+    def __getitem__(self, indexes: int | Sequence[int]) -> Tensor:
+        disparity = self._disparity(indexes)
+        match self._output:
+            case DisparityOutput.disparity:
+                return disparity
+
+            case DisparityOutput.valid:
+                return disparity > 0
+
+            case DisparityOutput.depth:
+                if self._stereo is None:
+                    raise RuntimeError
+
+                return disparity_to_depth(disparity, self._stereo)[0]
+
+    @override
+    def __len__(self) -> int:
+        return self._decoder.metadata.num_frames or 0

--- a/tests/data/nero_arms/calibration.yaml
+++ b/tests/data/nero_arms/calibration.yaml
@@ -45,4 +45,25 @@ cameras:
       - [0.0, 0.0, 1.0, 0.0]
       - [0.0, 0.0, 0.0, 1.0]
 
+# §21: the MONO pair behind the depth stream, MEASURED off the device
+# (OAK-D W, mxid 194430100104372F00). These are NOT the `cameras.base`
+# intrinsics above -- that is CAM_A, the RGB camera, a much narrower lens.
+# `fx_mono` is expressed at `image_size`, and the disparity frames must be
+# decoded at exactly that size: a resize scales fx but NOT the stored
+# disparity levels, so depth would come out wrong by the resize factor.
+#
+# Derived range at these values (fx_mono * baseline_m = 43.228 m*px):
+#   MinZ 0.455 m (max_disparity 95) / 0.226 m (extended, 191); far limit
+#   43.2 m at disparity 1. Check MinZ against the actual mount height.
+stereo:
+  base:
+    fx_mono: 576.37 # CAM_B @ 1280x800, HFOV 96.0 deg (CAM_C reads 566.77)
+    baseline_m: 0.075 # getBaselineDistance() = 7.5000 cm exactly
+    image_size: [1280, 800]
+    mono_sockets: [CAM_B, CAM_C]
+    max_disparity: 95 # §21.1: 191 if `extended_disparity`
+    subpixel: false # §21.1: MUST be false -- 8-bit cannot hold 760 levels
+    extended_disparity: false
+    placeholder: false # MEASURED, unlike the extrinsics above
+
 placeholder: true # MUST be false before any real training run

--- a/tests/test_nero.py
+++ b/tests/test_nero.py
@@ -6,24 +6,42 @@ are ~2.4 GB and are deliberately not vendored into `tests/data`.
 """
 
 import os
+import subprocess  # noqa: S404
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from types import SimpleNamespace
 
+import imageio_ffmpeg
 import numpy as np
 import polars as pl
 import pytest
+import torch
+import yaml
+from google.protobuf import descriptor_pb2, descriptor_pool, message_factory
+from mcap.writer import Writer
+from pydantic import ValidationError
+from torchcodec.decoders import VideoDecoder
 
 from rbyte.io.nero import (
     CAMERA_COND_DIM,
     CAMERAS,
+    DISPARITY_METADATA_PREFIX,
+    DISPARITY_TOPIC_PREFIX,
+    FINGERS,
     IMU_DIM,
+    MAX_DISPARITY,
     SIDES,
     STATE_DIM_9D,
     STATE_DIM_QUAT,
     STATUS_SENSORS,
+    DisparityDeclaration,
+    DisparityOutput,
     NeroArmsCalibration,
     NeroArmsDataFrameBuilder,
+    NeroArmsDisparityFrameSource,
+    StereoCalibration,
     canonicalize_quat,
+    disparity_to_depth,
     pose_9d_to_quat,
     pose_quat_to_9d,
     quat_slerp,
@@ -440,3 +458,639 @@ def test_episode_lengths_are_not_uniform() -> None:
     }
 
     assert len(set(lengths.values())) > 1, f"expected varying lengths, got {lengths}"
+
+
+# ============================================================ §21 depth stream
+#
+# No recording carries depth yet (§21 is a design section), so everything below
+# runs against a synthesised episode: FFV1-encoded uint8 disparity frames plus a
+# minimal MCAP carrying the `observation.disparity.base` index topic and the
+# §21.3 episode-metadata declaration.
+
+
+#: the synthetic rig. `fx_mono * baseline_m` == 30.0 m*px, so disparity 1 is
+#: 30 m and disparity 95 is 30/95 m -- both hand-checkable.
+FX_MONO = 400.0
+#: the MEASURED `base` OAK-D W mono pair (CAM_B @ 1280x800), §21.5.
+FX_MONO_BASE = 576.37
+#: derived range at the measured values -- `CAMERA_RIG.md` §4.2
+MIN_DEPTH_M = 0.455
+MIN_DEPTH_EXTENDED_M = 0.226
+MAX_DEPTH_M = 43.2
+BASELINE_M = 0.075
+DISPARITY_SIZE = (64, 48)  # (width, height)
+N_DISPARITY_FRAMES = 58
+N_CAMERA_FRAMES = 60
+#: §21.1: extended disparity halves MinZ and doubles the level count.
+EXTENDED_MAX_DISPARITY = 191
+#: §21.3: the disparity stream starts two camera frames late, so its own
+#: `frame_index` is NOT the camera's -- which is the point of the separate join.
+DISPARITY_START_FRAME = 2
+
+_GLOVE_PERIOD_NS = 11_987_000
+_CAMERA_PERIOD_NS = 33_333_333
+_LATENCY_NS = 5_000_000
+_T0_NS = 1_000_000_000
+_GLOVE_EPOCH_NS = 700_000_000_000
+_CAMERA_EPOCH_NS = 300_000_000_000
+
+
+def _stereo(**overrides: object) -> StereoCalibration:
+    return StereoCalibration.model_validate(
+        {
+            "fx_mono": FX_MONO,
+            "baseline_m": BASELINE_M,
+            "image_size": DISPARITY_SIZE,
+            "max_disparity": MAX_DISPARITY[False],
+            "subpixel": False,
+            "extended_disparity": False,
+            "placeholder": False,
+        }
+        | overrides
+    )
+
+
+def _declaration(**overrides: str) -> dict[str, str]:
+    """§21.3 episode metadata as the recorder writes it: `dict[str, str]`."""
+    width, height = DISPARITY_SIZE
+
+    return {
+        "max_disparity": str(MAX_DISPARITY[False]),
+        "subpixel": "false",
+        "extended_disparity": "false",
+        "width": str(width),
+        "height": str(height),
+        "mono_sockets": "CAM_B,CAM_C",
+    } | overrides
+
+
+def _synthetic_disparity(n: int = N_DISPARITY_FRAMES) -> np.ndarray:
+    """Depth-like uint8 disparity: a ramp that moves, plus an invalid block.
+
+    Values stay in `1..max_disparity`; `0` is reserved for the §21.4 invalid
+    region, which must never become a 0 m reading.
+    """
+    width, height = DISPARITY_SIZE
+    ramp = (1 + (np.arange(width) * (MAX_DISPARITY[False] - 1)) // width).astype(
+        np.uint8
+    )
+    frames = np.stack([
+        np.roll(np.broadcast_to(ramp, (height, width)), k, 1) for k in range(n)
+    ])
+    frames[:, :8, :8] = 0
+
+    return np.ascontiguousarray(frames)
+
+
+def _encode(
+    path: Path, frames: np.ndarray, *, pix_fmt: str, codec: str = "ffv1"
+) -> Path:
+    """Encode with imageio-ffmpeg's vendored binary (the system one is broken)."""
+    n, height, width = frames.shape
+    del n
+    subprocess.run(  # noqa: S603
+        [
+            imageio_ffmpeg.get_ffmpeg_exe(),
+            "-y",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            pix_fmt,
+            "-s",
+            f"{width}x{height}",
+            "-r",
+            "30",
+            "-i",
+            "pipe:0",
+            "-c:v",
+            codec,
+            "-pix_fmt",
+            pix_fmt,
+            path.as_posix(),
+        ],
+        input=frames.tobytes(),
+        check=True,
+    )
+
+    return path
+
+
+# ------------------------------------------------------- synthetic MCAP episode
+
+_FIELD = descriptor_pb2.FieldDescriptorProto  # ty: ignore[unresolved-attribute]
+_SCHEMAS: dict[str, tuple[tuple[str, int], ...]] = {
+    "Transform": tuple(
+        (name, _FIELD.TYPE_DOUBLE) for name in ("x", "y", "z", "qx", "qy", "qz", "qw")
+    ),
+    "Orientation": tuple(
+        (name, _FIELD.TYPE_DOUBLE) for name in ("qx", "qy", "qz", "qw")
+    ),
+    "ImageFrameIndex": (
+        ("frame_index", _FIELD.TYPE_UINT32),
+        ("sequence_number", _FIELD.TYPE_UINT64),
+        ("device_timestamp_ns", _FIELD.TYPE_UINT64),
+        ("host_arrival_time_ns", _FIELD.TYPE_UINT64),
+    ),
+    "SensorFrameTiming": (
+        ("device_id", _FIELD.TYPE_UINT32),
+        ("group_id", _FIELD.TYPE_UINT32),
+        ("device_timestamp_us", _FIELD.TYPE_UINT64),
+        ("host_arrival_time_ns", _FIELD.TYPE_UINT64),
+    ),
+}
+
+
+def _proto_types() -> tuple[bytes, dict[str, type]]:
+    """The §2 message shapes, built without protoc so the fixture is hermetic."""
+    file = descriptor_pb2.FileDescriptorProto(  # ty: ignore[unresolved-attribute]
+        name="nero_recording.proto", package="nero", syntax="proto3"
+    )
+    for name, fields in _SCHEMAS.items():
+        message = file.message_type.add()
+        message.name = name
+        for number, (field_name, field_type) in enumerate(fields, start=1):
+            field = message.field.add()
+            field.name, field.number = field_name, number
+            field.type, field.label = field_type, _FIELD.LABEL_OPTIONAL
+
+    pool = descriptor_pool.DescriptorPool()  # ty: ignore[possibly-missing-implicit-call]
+    pool.Add(file)
+
+    return (
+        descriptor_pb2.FileDescriptorSet(file=[file]).SerializeToString(),  # ty: ignore[unresolved-attribute]
+        {
+            name: message_factory.GetMessageClass(
+                pool.FindMessageTypeByName(f"nero.{name}")
+            )
+            for name in _SCHEMAS
+        },
+    )
+
+
+def _write_episode(
+    path: Path,
+    *,
+    declaration: Mapping[str, str] | None,
+    n_camera: int = N_CAMERA_FRAMES,
+    n_disparity: int = N_DISPARITY_FRAMES,
+    n_glove: int = 200,
+) -> Path:
+    """A minimal right-hand, single-camera episode with a disparity stream.
+
+    Device clocks are exact and the host clock is device + a constant latency +
+    non-negative jitter whose minimum is zero, which is what §3.2's
+    minimum-latency estimator is defined against.
+    """
+    descriptor_set, types = _proto_types()
+    rng = np.random.default_rng(0)
+
+    def jitter(n: int) -> np.ndarray:
+        out = rng.integers(0, 8_000_000, size=n)
+        out[0] = 0
+
+        return out
+
+    with path.open("wb") as f:
+        writer = Writer(f)
+        writer.start()
+
+        schema_ids = {
+            name: writer.register_schema(
+                name=f"nero.{name}", encoding="protobuf", data=descriptor_set
+            )
+            for name in _SCHEMAS
+        }
+
+        def channel(topic: str, schema: str) -> int:
+            return writer.register_channel(
+                topic=topic, message_encoding="protobuf", schema_id=schema_ids[schema]
+            )
+
+        # glove: `timing.rgmp` plus one sample per pose topic, ordinally joined
+        glove_true = _T0_NS + np.arange(n_glove) * _GLOVE_PERIOD_NS
+        glove_host = glove_true + _LATENCY_NS + jitter(n_glove)
+        timing = channel("timing.rgmp", "SensorFrameTiming")
+        for i in range(n_glove):
+            message = types["SensorFrameTiming"](
+                device_id=1,
+                group_id=0,
+                device_timestamp_us=(glove_true[i] + _GLOVE_EPOCH_NS) // 1_000,
+                host_arrival_time_ns=glove_host[i],
+            )
+            writer.add_message(
+                timing, glove_host[i], message.SerializeToString(), glove_host[i]
+            )
+
+        pose_topics = [
+            "right.arm_sensor.coil_pro.transform",
+            *(f"right.{finger}_finger_sensor.hub.transform" for finger in FINGERS),
+        ]
+        for t, topic in enumerate(pose_topics):
+            channel_id = channel(topic, "Transform")
+            for i in range(n_glove):
+                message = types["Transform"](
+                    x=0.1 * t + 1e-3 * i,
+                    y=0.2 * t,
+                    z=0.3 * t,
+                    qx=0.0,
+                    qy=0.0,
+                    qz=0.0,
+                    qw=1.0,
+                )
+                writer.add_message(
+                    channel_id,
+                    glove_host[i],
+                    message.SerializeToString(),
+                    glove_host[i],
+                )
+
+        channel_id = channel("right.hub.LTP_NED.orientation", "Orientation")
+        for i in range(n_glove):
+            message = types["Orientation"](qx=0.0, qy=0.0, qz=0.0, qw=1.0)
+            writer.add_message(
+                channel_id, glove_host[i], message.SerializeToString(), glove_host[i]
+            )
+
+        # `ImageFrameIndex` streams: the camera, and the disparity stream on its
+        # own index, starting `DISPARITY_START_FRAME` camera frames later (§3).
+        def frame_index_stream(topic: str, n: int, start_frame: int) -> None:
+            channel_id = channel(topic, "ImageFrameIndex")
+            true = (
+                _T0_NS + 20_000_000 + (start_frame + np.arange(n)) * _CAMERA_PERIOD_NS
+            )
+            host = true + _LATENCY_NS + jitter(n)
+            for k in range(n):
+                message = types["ImageFrameIndex"](
+                    frame_index=k,
+                    sequence_number=k,
+                    device_timestamp_ns=int(true[k] + _CAMERA_EPOCH_NS),
+                    host_arrival_time_ns=int(host[k]),
+                )
+                writer.add_message(
+                    channel_id, int(host[k]), message.SerializeToString(), int(host[k])
+                )
+
+        frame_index_stream("observation.images.base", n_camera, 0)
+        frame_index_stream(
+            f"{DISPARITY_TOPIC_PREFIX}base", n_disparity, DISPARITY_START_FRAME
+        )
+
+        writer.add_metadata(
+            "episode",
+            {"task": "synthetic", "active_hand": "right", "episode_id": "synthetic"},
+        )
+        if declaration is not None:
+            writer.add_metadata(f"{DISPARITY_METADATA_PREFIX}base", dict(declaration))
+
+        writer.finish()
+
+    return path
+
+
+@pytest.fixture(scope="session")
+def disparity_frames() -> np.ndarray:
+    return _synthetic_disparity()
+
+
+@pytest.fixture(scope="session")
+def disparity_mkv(
+    tmp_path_factory: pytest.TempPathFactory, disparity_frames: np.ndarray
+) -> Path:
+    """§21.2: 8-bit `gray` FFV1 in MKV, exactly what the recorder will write."""
+    return _encode(
+        tmp_path_factory.mktemp("disparity") / "base_disparity.mkv",
+        disparity_frames,
+        pix_fmt="gray",
+    )
+
+
+def _builder(disparity_cameras: Sequence[str] = ()) -> NeroArmsDataFrameBuilder:
+    return NeroArmsDataFrameBuilder(
+        cameras=["base"],
+        reference_camera="base",
+        sides=["right"],
+        disparity_cameras=disparity_cameras,
+    )
+
+
+# ------------------------------------------------------------ §21.1 declaration
+
+
+def test_stereo_calibration_rejects_subpixel() -> None:
+    """§21.4: an 8-bit read of subpixel disparity is wrong by a factor of 8."""
+    with pytest.raises(ValidationError, match="subpixel"):
+        _stereo(subpixel=True, max_disparity=760)
+
+
+def test_declaration_rejects_subpixel() -> None:
+    with pytest.raises(ValidationError, match="subpixel"):
+        DisparityDeclaration.from_mcap_metadata(
+            _declaration(subpixel="true", max_disparity="760")
+        )
+
+
+def test_declaration_rejects_max_disparity_contradiction() -> None:
+    """§21.3: assuming 95 when extended disparity was on halves every depth."""
+    with pytest.raises(ValidationError, match="max_disparity"):
+        DisparityDeclaration.from_mcap_metadata(_declaration(extended_disparity="true"))
+
+    with pytest.raises(ValidationError, match="max_disparity"):
+        _stereo(extended_disparity=True)
+
+
+def test_declaration_accepts_extended_disparity() -> None:
+    declaration = DisparityDeclaration.from_mcap_metadata(
+        _declaration(extended_disparity="true", max_disparity=str(MAX_DISPARITY[True]))
+    )
+
+    assert declaration.max_disparity == MAX_DISPARITY[True] == EXTENDED_MAX_DISPARITY
+    assert not declaration.subpixel
+    # §21.3: declared, never inferred -- including the mono pair used
+    assert declaration.mono_sockets == "CAM_B,CAM_C"
+
+
+def test_declaration_must_disagree_loudly_with_calibration() -> None:
+    declaration = DisparityDeclaration.from_mcap_metadata(_declaration())
+    declaration.check_against(_stereo(), camera="base")
+
+    with pytest.raises(ValueError, match="disagrees"):
+        declaration.check_against(_stereo(image_size=(1280, 800)), camera="base")
+
+
+def test_shipped_calibration_carries_the_measured_mono_pair() -> None:
+    """§21.5, now measured: the MONO pair, not the RGB `CAM_A` above it."""
+    stereo = NeroArmsCalibration.from_path(CALIBRATION_PATH).stereo_for("base")
+
+    assert (stereo.fx_mono, stereo.baseline_m) == (FX_MONO_BASE, BASELINE_M)
+    assert stereo.image_size == (1280, 800), "`fx_mono` is expressed at this size"
+    assert stereo.mono_sockets == ("CAM_B", "CAM_C")
+    assert not stereo.placeholder
+    # the RGB CAM_A fx is 1152.2 -- using it would scale every depth by 2x
+    assert (
+        stereo.fx_mono
+        != NeroArmsCalibration.from_path(CALIBRATION_PATH).cameras["base"].intrinsics.fx
+    )
+
+
+def test_measured_stereo_reproduces_the_documented_range() -> None:
+    """`CAMERA_RIG.md` §4.2: MinZ must be checked against the mount height."""
+    stereo = NeroArmsCalibration.from_path(CALIBRATION_PATH).stereo_for("base")
+
+    assert round(stereo.min_depth_m, 3) == MIN_DEPTH_M, "MinZ, default mode"
+    assert round(stereo.max_depth_m, 1) == MAX_DEPTH_M, "far limit at disparity 1"
+
+    extended = stereo.model_copy(
+        update={"max_disparity": MAX_DISPARITY[True], "extended_disparity": True}
+    )
+
+    assert round(extended.min_depth_m, 3) == MIN_DEPTH_EXTENDED_M, (
+        "MinZ, extended disparity"
+    )
+
+    # the same numbers through the conversion the ingestion actually uses
+    depth, valid = disparity_to_depth(
+        torch.tensor([0, 1, stereo.max_disparity], dtype=torch.uint8), stereo
+    )
+
+    assert np.allclose(depth.numpy(), [0.0, stereo.max_depth_m, stereo.min_depth_m])
+    assert (valid.numpy() == [False, True, True]).all()
+
+
+def _without_stereo(tmp_path: Path) -> Path:
+    """The pre-measurement shape of the sidecar: no `stereo:` block at all."""
+    calibration = yaml.safe_load(CALIBRATION_PATH.read_text(encoding="utf-8"))
+    del calibration["stereo"]
+    path = tmp_path / "calibration.yaml"
+    path.write_text(yaml.safe_dump(calibration), encoding="utf-8")
+
+    return path
+
+
+def test_absent_stereo_block_is_refused(tmp_path: Path) -> None:
+    """§21.4: no safe default -- a guessed `fx_mono` scales every depth."""
+    calibration = NeroArmsCalibration.from_path(_without_stereo(tmp_path))
+
+    assert calibration.stereo == {}
+
+    with pytest.raises(ValueError, match="no `stereo` calibration"):
+        calibration.stereo_for("base")
+
+
+def test_placeholder_stereo_is_refused() -> None:
+    calibration = NeroArmsCalibration.from_path(CALIBRATION_PATH).model_copy(deep=True)
+    calibration.stereo = {"base": _stereo(placeholder=True)}
+
+    with pytest.raises(ValueError, match="PLACEHOLDER"):
+        calibration.stereo_for("base")
+
+
+# -------------------------------------------------------------- §21.4 conversion
+
+
+def test_disparity_to_depth_matches_hand_computed_values() -> None:
+    disparity = torch.tensor([[0, 1, 2, 30, 95]], dtype=torch.uint8)
+    depth, valid = disparity_to_depth(disparity, _stereo())
+
+    # fx_mono * baseline_m == 400 * 0.075 == 30.0 m*px
+    assert np.allclose(depth.numpy(), [[0.0, 30.0, 15.0, 1.0, 30.0 / 95.0]], atol=1e-6)
+    assert (valid.numpy() == [[False, True, True, True, True]]).all()
+
+
+def test_invalid_disparity_is_masked_never_zero_metres() -> None:
+    """§21.4: `disparity == 0` is INVALID, not zero distance."""
+    disparity = torch.zeros((4, 4), dtype=torch.uint8)
+    depth, valid = disparity_to_depth(disparity, _stereo())
+
+    assert not valid.any(), "every pixel is invalid"
+    assert torch.isfinite(depth).all(), "no inf: the denominator is clamped first"
+    assert not torch.isnan(depth * valid).any(), "inf * 0 would be nan"
+    # the value is 0.0 *and* masked -- a consumer that ignores the mask must not
+    # be able to mistake it for a valid reading, which is what the mask is for
+    assert (depth == 0.0).all()  # noqa: RUF069  -- exactly the constant written above
+
+
+# ------------------------------------------------------------------ §21.2 decode
+
+
+def test_ffv1_gray8_decodes_bit_exact(
+    disparity_mkv: Path, disparity_frames: np.ndarray
+) -> None:
+    source = NeroArmsDisparityFrameSource(source=disparity_mkv)
+
+    assert len(source) == N_DISPARITY_FRAMES
+
+    single = source[3]
+
+    assert single.shape == (1, DISPARITY_SIZE[1], DISPARITY_SIZE[0])
+    assert single.dtype == torch.uint8
+    assert np.array_equal(single.numpy()[0], disparity_frames[3])
+
+    batch = source[[0, 7, 11]]
+
+    assert batch.shape == (3, 1, DISPARITY_SIZE[1], DISPARITY_SIZE[0])
+    assert np.array_equal(batch.numpy()[:, 0], disparity_frames[[0, 7, 11]])
+
+
+def test_sixteen_bit_is_refused_not_silently_downconverted(tmp_path: Path) -> None:
+    """§21.2: torchcodec does not raise on 16-bit -- it returns wrong data."""
+    frames = _synthetic_disparity(4).astype("<u2") * 8  # as subpixel would store it
+    path = _encode(tmp_path / "d16.mkv", frames, pix_fmt="gray16le")
+
+    with pytest.raises(ValueError, match="PyAV"):
+        NeroArmsDisparityFrameSource(source=path)
+
+    # the failure mode being guarded against, demonstrated
+    decoded = VideoDecoder(path.as_posix()).get_frame_at(index=0).data
+
+    assert decoded.dtype == torch.uint8, "torchcodec silently down-converts"
+    assert not np.array_equal(decoded.numpy()[0], frames[0])
+
+
+def test_lossy_codec_is_refused(tmp_path: Path) -> None:
+    """§21.2: libx264 measured a max error of 81 levels at 95 full scale."""
+    path = _encode(
+        tmp_path / "lossy.mkv", _synthetic_disparity(4), pix_fmt="gray", codec="libx264"
+    )
+
+    with pytest.raises(ValueError, match="lossless"):
+        NeroArmsDisparityFrameSource(source=path)
+
+
+def test_depth_source_emits_metres_and_mask(
+    disparity_mkv: Path, disparity_frames: np.ndarray
+) -> None:
+    stereo = _stereo()
+    depth = NeroArmsDisparityFrameSource(
+        source=disparity_mkv, output=DisparityOutput.depth, stereo=stereo
+    )[[0, 5]]
+    valid = NeroArmsDisparityFrameSource(
+        source=disparity_mkv, output=DisparityOutput.valid
+    )[[0, 5]]
+
+    assert depth.dtype == torch.float32
+    assert valid.dtype == torch.bool
+    assert torch.isfinite(depth).all()
+
+    reference = disparity_frames[[0, 5]].astype(np.float64)
+    invalid = reference == 0
+
+    assert (valid.numpy()[:, 0] == ~invalid).all()
+    assert (depth.numpy()[:, 0][invalid] == 0.0).all()  # noqa: RUF069
+    assert np.allclose(
+        depth.numpy()[:, 0][~invalid],
+        (FX_MONO * BASELINE_M / reference[~invalid]),
+        atol=1e-5,
+    )
+
+
+def test_depth_without_stereo_calibration_fails_loudly(
+    disparity_mkv: Path, tmp_path: Path
+) -> None:
+    """§21.4: without the mono `fx`/baseline, refuse -- never guess."""
+    with pytest.raises(ValueError, match="no `stereo` calibration"):
+        NeroArmsDisparityFrameSource(
+            source=disparity_mkv,
+            output=DisparityOutput.depth,
+            camera="base",
+            calibration_path=_without_stereo(tmp_path),
+        )
+
+    with pytest.raises(ValueError, match="calibration_path"):
+        NeroArmsDisparityFrameSource(source=disparity_mkv, output=DisparityOutput.depth)
+
+    # raw disparity must still work with no calibration at all
+    assert NeroArmsDisparityFrameSource(source=disparity_mkv)[0].dtype == torch.uint8
+
+
+def test_depth_rejects_a_resolution_mismatch(disparity_mkv: Path) -> None:
+    """`fx_mono` describes one resolution; anything else scales every depth."""
+    with pytest.raises(ValueError, match="image_size"):
+        NeroArmsDisparityFrameSource(
+            source=disparity_mkv,
+            output=DisparityOutput.depth,
+            stereo=_stereo(image_size=(1280, 800)),
+        )
+
+
+# ------------------------------------------------------------------ §21.4 join
+
+
+@pytest.fixture(scope="session")
+def calibration_no_stereo(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """The join tests care about indexes, not about metric depth."""
+    return _without_stereo(tmp_path_factory.mktemp("calibration"))
+
+
+@pytest.fixture(scope="session")
+def disparity_episode(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return _write_episode(
+        tmp_path_factory.mktemp("episode") / "data.mcap", declaration=_declaration()
+    )
+
+
+def test_builder_joins_disparity_on_its_own_frame_index(
+    disparity_episode: Path, calibration_no_stereo: Path
+) -> None:
+    """§3/§21.4: the disparity stream has its own, shorter, index."""
+    df = _builder(["base"])(disparity_episode, calibration_no_stereo)
+
+    assert "frame_index.disparity.base" in df.columns
+    assert "goal.frame_index.disparity.base" in df.columns
+
+    base = df["frame_index.base"].to_numpy()
+    disparity = df["frame_index.disparity.base"].to_numpy()
+
+    assert disparity.max() < N_DISPARITY_FRAMES < N_CAMERA_FRAMES
+    # the stream starts two camera frames late, so its index trails by two --
+    # anything that assumed a shared index would fail here
+    late = base >= DISPARITY_START_FRAME
+
+    assert (disparity[late] == base[late] - DISPARITY_START_FRAME).all()
+    assert (disparity[~late] == 0).all(), "clipped, never negative or extrapolated"
+    assert int(df["goal.frame_index.disparity.base"][0]) == N_DISPARITY_FRAMES - 1
+
+
+def test_builder_without_disparity_is_unchanged(
+    disparity_episode: Path, calibration_no_stereo: Path
+) -> None:
+    """The depth stream is optional and off by default (§8)."""
+    df = _builder()(disparity_episode, calibration_no_stereo)
+
+    assert not [c for c in df.columns if "disparity" in c]
+    assert df["frame_index.base"].is_sorted(descending=False)
+
+
+def test_builder_requires_the_declaration(
+    tmp_path: Path, calibration_no_stereo: Path
+) -> None:
+    """§17.1: presence is declared, never inferred from absence."""
+    path = _write_episode(tmp_path / "data.mcap", declaration=None)
+
+    with pytest.raises(ValueError, match="does not declare"):
+        _builder(["base"])(path, calibration_no_stereo)
+
+    # ... and without disparity ingestion the same episode is fine
+    assert len(_builder()(path, calibration_no_stereo)) > 0
+
+
+def test_builder_rejects_declared_subpixel(
+    tmp_path: Path, calibration_no_stereo: Path
+) -> None:
+    path = _write_episode(
+        tmp_path / "data.mcap",
+        declaration=_declaration(subpixel="true", max_disparity="760"),
+    )
+
+    with pytest.raises(ValidationError, match="subpixel"):
+        _builder(["base"])(path, calibration_no_stereo)
+
+
+def test_builder_cross_checks_the_declaration_against_calibration(
+    disparity_episode: Path,
+) -> None:
+    """§21.3: the episode declares 64x48; the measured rig says 1280x800."""
+    with pytest.raises(ValueError, match="disagrees"):
+        _builder(["base"])(disparity_episode, CALIBRATION_PATH)

--- a/tests/test_nero.py
+++ b/tests/test_nero.py
@@ -767,6 +767,57 @@ def disparity_mkv(
     )
 
 
+@pytest.fixture(scope="session")
+def disparity_mkv_measured(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Disparity at the MEASURED `stereo.image_size`, so the size guard's
+    *passing* branch and the `calibration_path` resolution both get exercised at
+    the resolution the real rig will use."""
+    width, height = 1280, 800
+    # 1 .. max_disparity inclusive, so both range endpoints are actually present
+    ramp = (1 + (np.arange(width) * MAX_DISPARITY[False]) // width).astype(np.uint8)
+    frames = np.ascontiguousarray(
+        np.stack([
+            np.roll(np.broadcast_to(ramp, (height, width)), k, 1) for k in range(4)
+        ])
+    )
+    frames[:, :16, :16] = 0
+
+    return _encode(
+        tmp_path_factory.mktemp("measured") / "base_disparity.mkv",
+        frames,
+        pix_fmt="gray",
+    )
+
+
+def test_depth_through_the_shipped_calibration_path(
+    disparity_mkv_measured: Path,
+) -> None:
+    """The path the config template takes: `camera` + `calibration_path`."""
+    source = NeroArmsDisparityFrameSource(
+        source=disparity_mkv_measured,
+        output=DisparityOutput.depth,
+        camera="base",
+        calibration_path=CALIBRATION_PATH,
+    )
+    disparity = NeroArmsDisparityFrameSource(source=disparity_mkv_measured)[0]
+    depth = source[0]
+    valid = NeroArmsDisparityFrameSource(
+        source=disparity_mkv_measured, output=DisparityOutput.valid
+    )[0]
+
+    assert depth.shape == (1, 800, 1280)
+    assert torch.isfinite(depth).all()
+    assert (valid.numpy() == (disparity.numpy() > 0)).all()
+
+    levels = disparity.numpy()[0]
+
+    assert round(float(depth.numpy()[0][levels == MAX_DISPARITY[False]].max()), 3) == (
+        MIN_DEPTH_M
+    ), "disparity 95 must land on the documented MinZ"
+    assert round(float(depth.numpy()[0][levels == 1].max()), 1) == MAX_DEPTH_M
+    assert (depth.numpy()[0][levels == 0] == 0.0).all()  # noqa: RUF069
+
+
 def _builder(disparity_cameras: Sequence[str] = ()) -> NeroArmsDataFrameBuilder:
     return NeroArmsDataFrameBuilder(
         cameras=["base"],


### PR DESCRIPTION
Ingests the overhead depth stream: decodes 8-bit disparity, converts it to metric depth, and emits it with an explicit validity mask.

> **Stacked on [#109](https://github.com/yaak-ai/rbyte/pull/109)** (base `feat/nero-arms`). Review that first. The matching recorder is [nutron-cli#4](https://github.com/yaak-ai/nutron-cli/pull/4).

Design is specified in `nero-arms/DATA_CONTRACT.md` §21. **Off by default** — `disparity_cameras` is empty, so existing configs and the 15,047-sample dataset are untouched.

## What's here

| file | what |
|---|---|
| `src/rbyte/io/nero/disparity.py` | `DisparityOutput`, `DisparityDeclaration` (§21.3 metadata), `disparity_to_depth`. No torchcodec import, so `rbyte.io.nero` still loads without the `video` extra |
| `src/rbyte/io/nero/disparity_source.py` | `NeroArmsDisparityFrameSource` — the decoder plus its guards |
| `src/rbyte/io/nero/calibration.py` | `StereoCalibration`, optional `stereo:` dict keyed by camera, `stereo_for()` fail-loud accessor, `min_depth_m`/`max_depth_m` |
| `src/rbyte/io/nero/dataframe_builder.py` | `observation.disparity.{cam}` joined through the **same** code path as the mp4 cameras |
| `config/_templates/dataset/nero_arms.yaml` | one ytt `depth` flag gating four coordinated edits; verified by rendering both ways |

## The guards are the point

**16-bit refusal is real, not decorative.** torchcodec silently down-converts 16-bit video to uint8 — it does not raise, it returns plausible wrong data. Confirmed torchcodec 0.15's `pixel_format` reports the *source* stream format, so the check fires; a `gray16le` fixture proves it, and the same test demonstrates the silent corruption it prevents. Lossy codecs are refused too, with the codec check running first because libx264 `-pix_fmt gray` actually stores `yuvj420p` and would otherwise produce a confusing message.

**`disparity == 0` is invalid, not zero distance.** Two streams over one file (`depth`, `valid`), since an rbyte stream is a single tensor. The denominator is clamped *before* division, so invalid pixels come out `0.0` **and** masked — never `inf` or `nan`.

**No transforms are exposed on the source.** Resizing scales `fx` but not the stored disparity levels, so a resized frame would yield depth wrong by exactly the resize factor. Frame size must equal `stereo.image_size`, and that equality is enforced rather than assumed — see §21.11: the calibration is authored at the *recorded* resolution precisely so this check proves the two match.

**Declarations are read, never inferred.** `subpixel` must be false (an 8-bit read of subpixel disparity is wrong by 32×), and `max_disparity` must agree with `extended_disparity`. Episode metadata is authoritative per-episode; a disagreement with calibration is a hard failure, and a missing record never silently falls back.

## Verified

- `tests/test_nero.py`: **49 passed** (baseline 26).
- Full suite: **65 passed, 7 skipped, 5 errors** against a 42/7/5 baseline — the same 5 pre-existing fixture errors from the unavailable private `idl-repo` submodule.
- **Existing ingestion is byte-identical.** Three real episodes from `/nasa/.../2026-07-17/` were rebuilt and compared against parquet snapshots taken before any change — identical data, identical schema.
- Measured mono intrinsics are folded in and tested end-to-end: MinZ **0.455 m** (0.226 m extended), far limit **43.2 m**, asserted through `disparity_to_depth` via the same `camera` + `calibration_path` path the config uses.
- The recorder's actual metadata dict parses through `DisparityDeclaration` — checked across both repos, which caught a record-name mismatch before either side shipped.

## Still outstanding

1. **nutron-cli must land** — no recording with depth exists yet, so all testing is against synthesised FFV1 fixtures.
2. **The `stereo:` block is only in `tests/data`.** `/nasa/.../2026-07-17/calibration.yaml` has none, and neither does `nero-arms/calibration_measured.yaml`. Per §21.11 it must be authored at the **recorded** depth resolution (`fx_mono: 288.19` at 640×400, read directly rather than scaled by hand) — not at mono native.
3. Minor: `mono_sockets` is a comma-string in metadata and a `tuple[str, str]` in calibration; `check_against` does not compare them.

## Note on the contract

§21.3 originally required the metadata declarations to exist but never named the record, which is exactly how the recorder and this consumer diverged. §21.10 now pins the record name (`disparity.{camera}`) and its required keys normatively, and §21.11 pins which side owns the resolution scaling. Both are the kind of ambiguity that produces two individually-correct implementations that cannot talk to each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
